### PR TITLE
Add TupleSchemaBuilder for fixed-length arrays with type validation

### DIFF
--- a/libs/schema-json/src/fromJsonSchema.test.ts
+++ b/libs/schema-json/src/fromJsonSchema.test.ts
@@ -831,6 +831,8 @@ test('fromJsonSchema - 54: prefixItems → tuple accepts exact length', () => {
     const schema = fromJsonSchema({
         type: 'array',
         prefixItems: [{ type: 'string' }, { type: 'number' }],
+        minItems: 2,
+        maxItems: 2,
         items: false
     } as const);
     expect(valid(schema, ['hello', 42])).toBe(true);
@@ -840,6 +842,8 @@ test('fromJsonSchema - 55: prefixItems → tuple rejects too short', () => {
     const schema = fromJsonSchema({
         type: 'array',
         prefixItems: [{ type: 'string' }, { type: 'number' }],
+        minItems: 2,
+        maxItems: 2,
         items: false
     } as const);
     expect(valid(schema, ['hello'])).toBe(false);
@@ -849,6 +853,8 @@ test('fromJsonSchema - 56: prefixItems + items:false → rejects extra elements'
     const schema = fromJsonSchema({
         type: 'array',
         prefixItems: [{ type: 'string' }, { type: 'number' }],
+        minItems: 2,
+        maxItems: 2,
         items: false
     } as const);
     expect(valid(schema, ['hello', 42, 'extra'])).toBe(false);
@@ -858,6 +864,7 @@ test('fromJsonSchema - 57: prefixItems + items:schema → accepts rest elements'
     const schema = fromJsonSchema({
         type: 'array',
         prefixItems: [{ type: 'string' }],
+        minItems: 1,
         items: { type: 'number' }
     } as const);
     expect(valid(schema, ['hello', 1, 2, 3])).toBe(true);
@@ -867,6 +874,7 @@ test('fromJsonSchema - 58: prefixItems + items:schema → rejects wrong-typed re
     const schema = fromJsonSchema({
         type: 'array',
         prefixItems: [{ type: 'string' }],
+        minItems: 1,
         items: { type: 'number' }
     } as const);
     expect(valid(schema, ['hello', 'notANumber'])).toBe(false);
@@ -876,6 +884,8 @@ test('fromJsonSchema - 59: empty prefixItems → empty tuple', () => {
     const schema = fromJsonSchema({
         type: 'array',
         prefixItems: [],
+        minItems: 0,
+        maxItems: 0,
         items: false
     } as const);
     expect(valid(schema, [])).toBe(true);

--- a/libs/schema-json/src/fromJsonSchema.test.ts
+++ b/libs/schema-json/src/fromJsonSchema.test.ts
@@ -822,3 +822,62 @@ test('fromJsonSchema - 53: create product — optional stock may be absent', () 
         })
     ).toBe(true);
 });
+
+// ---------------------------------------------------------------------------
+// tuple (prefixItems)
+// ---------------------------------------------------------------------------
+
+test('fromJsonSchema - 54: prefixItems → tuple accepts exact length', () => {
+    const schema = fromJsonSchema({
+        type: 'array',
+        prefixItems: [{ type: 'string' }, { type: 'number' }],
+        items: false
+    } as const);
+    expect(valid(schema, ['hello', 42])).toBe(true);
+});
+
+test('fromJsonSchema - 55: prefixItems → tuple rejects too short', () => {
+    const schema = fromJsonSchema({
+        type: 'array',
+        prefixItems: [{ type: 'string' }, { type: 'number' }],
+        items: false
+    } as const);
+    expect(valid(schema, ['hello'])).toBe(false);
+});
+
+test('fromJsonSchema - 56: prefixItems + items:false → rejects extra elements', () => {
+    const schema = fromJsonSchema({
+        type: 'array',
+        prefixItems: [{ type: 'string' }, { type: 'number' }],
+        items: false
+    } as const);
+    expect(valid(schema, ['hello', 42, 'extra'])).toBe(false);
+});
+
+test('fromJsonSchema - 57: prefixItems + items:schema → accepts rest elements', () => {
+    const schema = fromJsonSchema({
+        type: 'array',
+        prefixItems: [{ type: 'string' }],
+        items: { type: 'number' }
+    } as const);
+    expect(valid(schema, ['hello', 1, 2, 3])).toBe(true);
+});
+
+test('fromJsonSchema - 58: prefixItems + items:schema → rejects wrong-typed rest', () => {
+    const schema = fromJsonSchema({
+        type: 'array',
+        prefixItems: [{ type: 'string' }],
+        items: { type: 'number' }
+    } as const);
+    expect(valid(schema, ['hello', 'notANumber'])).toBe(false);
+});
+
+test('fromJsonSchema - 59: empty prefixItems → empty tuple', () => {
+    const schema = fromJsonSchema({
+        type: 'array',
+        prefixItems: [],
+        items: false
+    } as const);
+    expect(valid(schema, [])).toBe(true);
+    expect(valid(schema, ['extra'])).toBe(false);
+});

--- a/libs/schema-json/src/fromJsonSchema.ts
+++ b/libs/schema-json/src/fromJsonSchema.ts
@@ -7,6 +7,7 @@ import {
     number,
     object,
     string,
+    tuple,
     union
 } from '@cleverbrush/schema';
 import type { JsonSchemaNodeToBuilder } from './types.js';
@@ -133,6 +134,21 @@ function buildNumber(
 function buildArray(
     node: Record<string, unknown>
 ): SchemaBuilder<any, any, any> {
+    // JSON Schema 2020-12 tuples use `prefixItems`
+    if (Array.isArray(node['prefixItems'])) {
+        const elements = (node['prefixItems'] as unknown[]).map(buildNode);
+        let b: any = tuple(elements as any);
+        // `items: false` means no extra elements (default for tuple)
+        // `items: <schema>` means rest elements validated against that schema
+        if (
+            node['items'] !== undefined &&
+            node['items'] !== false &&
+            typeof node['items'] === 'object'
+        ) {
+            b = b.rest(buildNode(node['items']));
+        }
+        return b;
+    }
     let b: any = array();
     if (node['items'] !== undefined) b = b.of(buildNode(node['items']));
     if (typeof node['minItems'] === 'number') b = b.minLength(node['minItems']);

--- a/libs/schema-json/src/toJsonSchema.test.ts
+++ b/libs/schema-json/src/toJsonSchema.test.ts
@@ -7,6 +7,7 @@ import {
     number,
     object,
     string,
+    tuple,
     union
 } from '@cleverbrush/schema';
 import { expect, test } from 'vitest';
@@ -287,4 +288,50 @@ test('toJsonSchema - 34: number().isInteger() stays integer', () => {
 test('toJsonSchema - 35: nul() round-trips to { type: null }', () => {
     const result = toJsonSchema(nul(), { $schema: false });
     expect(result).toEqual({ type: 'null' });
+});
+
+// ---------------------------------------------------------------------------
+// tuple
+// ---------------------------------------------------------------------------
+
+test('toJsonSchema - 36: tuple([string(), number()]) → prefixItems + items:false', () => {
+    const result = toJsonSchema(tuple([string(), number()]), {
+        $schema: false
+    });
+    expect(result).toEqual({
+        type: 'array',
+        prefixItems: [{ type: 'string' }, { type: 'integer' }],
+        items: false
+    });
+});
+
+test('toJsonSchema - 37: tuple([]) → empty prefixItems + items:false', () => {
+    const result = toJsonSchema(tuple([]), { $schema: false });
+    expect(result).toEqual({
+        type: 'array',
+        prefixItems: [],
+        items: false
+    });
+});
+
+test('toJsonSchema - 38: tuple([string()]).rest(number().isFloat()) → items: {type:number}', () => {
+    const result = toJsonSchema(tuple([string()]).rest(number().isFloat()), {
+        $schema: false
+    });
+    expect(result).toEqual({
+        type: 'array',
+        prefixItems: [{ type: 'string' }],
+        items: { type: 'number' }
+    });
+});
+
+test('toJsonSchema - 39: tuple([boolean(), string()]) → prefixItems order preserved', () => {
+    const result = toJsonSchema(tuple([boolean(), string()]), {
+        $schema: false
+    });
+    expect(result).toEqual({
+        type: 'array',
+        prefixItems: [{ type: 'boolean' }, { type: 'string' }],
+        items: false
+    });
 });

--- a/libs/schema-json/src/toJsonSchema.test.ts
+++ b/libs/schema-json/src/toJsonSchema.test.ts
@@ -301,6 +301,8 @@ test('toJsonSchema - 36: tuple([string(), number()]) → prefixItems + items:fal
     expect(result).toEqual({
         type: 'array',
         prefixItems: [{ type: 'string' }, { type: 'integer' }],
+        minItems: 2,
+        maxItems: 2,
         items: false
     });
 });
@@ -310,6 +312,8 @@ test('toJsonSchema - 37: tuple([]) → empty prefixItems + items:false', () => {
     expect(result).toEqual({
         type: 'array',
         prefixItems: [],
+        minItems: 0,
+        maxItems: 0,
         items: false
     });
 });
@@ -321,6 +325,7 @@ test('toJsonSchema - 38: tuple([string()]).rest(number().isFloat()) → items: {
     expect(result).toEqual({
         type: 'array',
         prefixItems: [{ type: 'string' }],
+        minItems: 1,
         items: { type: 'number' }
     });
 });
@@ -332,6 +337,8 @@ test('toJsonSchema - 39: tuple([boolean(), string()]) → prefixItems order pres
     expect(result).toEqual({
         type: 'array',
         prefixItems: [{ type: 'boolean' }, { type: 'string' }],
+        minItems: 2,
+        maxItems: 2,
         items: false
     });
 });

--- a/libs/schema-json/src/toJsonSchema.ts
+++ b/libs/schema-json/src/toJsonSchema.ts
@@ -81,6 +81,21 @@ function convertNode(schema: SchemaBuilder<any, any, any>): Out {
             return out;
         }
 
+        case 'tuple': {
+            const elements: SchemaBuilder<any, any, any>[] =
+                info.elements ?? [];
+            const out: Out = {
+                type: 'array',
+                prefixItems: elements.map(convertNode)
+            };
+            if (info.restSchema) {
+                out['items'] = convertNode(info.restSchema);
+            } else {
+                out['items'] = false;
+            }
+            return out;
+        }
+
         case 'object': {
             const out: Out = { type: 'object' };
             const props = info.properties as

--- a/libs/schema-json/src/toJsonSchema.ts
+++ b/libs/schema-json/src/toJsonSchema.ts
@@ -86,12 +86,14 @@ function convertNode(schema: SchemaBuilder<any, any, any>): Out {
                 info.elements ?? [];
             const out: Out = {
                 type: 'array',
-                prefixItems: elements.map(convertNode)
+                prefixItems: elements.map(convertNode),
+                minItems: elements.length
             };
             if (info.restSchema) {
                 out['items'] = convertNode(info.restSchema);
             } else {
                 out['items'] = false;
+                out['maxItems'] = elements.length;
             }
             return out;
         }

--- a/libs/schema/README.md
+++ b/libs/schema/README.md
@@ -113,6 +113,7 @@ The following builder functions are available:
 | `nul()`         | Exactly `null`. Useful in nullable unions.        | `.optional()`, `.default(value)`                                                   |
 | `object(props)` | Object with typed properties. Supports nesting.   | `.validate(data)`, `.addProps({...})`, `.optional()`, `.nullable()`, `.default(value)`            |
 | `array()`       | Array with optional element schema (via `.of()`). | `.minLength(n)`, `.maxLength(n)`, `.of(schema)`, `.nonempty()`, `.unique()`, `.nullable()`, `.default(value)` |
+| `tuple([...schemas])` | Fixed-length array with per-position types. Each index validated against its own schema — mirrors TypeScript tuple types. | `.rest(schema)`, `.optional()`, `.nullable()`, `.default(value)` |
 | `union(schema)` | Union of schemas — e.g. `string \| number`.       | `.or(schema)`, `.validate(data)`, `.optional()`, `.nullable()`, `.default(value)`                 |
 | `lazy(getter)`  | Recursive/self-referential schema. The getter is called once and its result is cached. Enables tree structures, linked lists, and other recursive types. | `.resolve()`, `.optional()`, `.addValidator(fn)`, `.default(value)` |
 

--- a/libs/schema/package.json
+++ b/libs/schema/package.json
@@ -58,6 +58,10 @@
             "types": "./dist/builders/UnionSchemaBuilder.d.ts",
             "import": "./dist/builders/UnionSchemaBuilder.js"
         },
+        "./tuple": {
+            "types": "./dist/builders/TupleSchemaBuilder.d.ts",
+            "import": "./dist/builders/TupleSchemaBuilder.js"
+        },
         "./function": {
             "types": "./dist/builders/FunctionSchemaBuilder.d.ts",
             "import": "./dist/builders/FunctionSchemaBuilder.js"

--- a/libs/schema/src/builders/TupleSchemaBuilder.test.ts
+++ b/libs/schema/src/builders/TupleSchemaBuilder.test.ts
@@ -1,0 +1,460 @@
+import { expect, expectTypeOf, test } from 'vitest';
+
+import { boolean } from './BooleanSchemaBuilder.js';
+import { number } from './NumberSchemaBuilder.js';
+import { object } from './ObjectSchemaBuilder.js';
+import type { InferType } from './SchemaBuilder.js';
+import { string } from './StringSchemaBuilder.js';
+import { TupleSchemaBuilder, tuple } from './TupleSchemaBuilder.js';
+import { union } from './UnionSchemaBuilder.js';
+
+// ---------------------------------------------------------------------------
+// Type-level tests
+// ---------------------------------------------------------------------------
+
+test('Types - basic tuple infers correct tuple type', () => {
+    const schema = tuple([string(), number(), boolean()]);
+    const val: InferType<typeof schema> = ['hello', 42, true];
+
+    expectTypeOf(val).toEqualTypeOf<[string, number, boolean]>();
+});
+
+test('Types - validate() parameter matches tuple type', () => {
+    const schema = tuple([string(), number(), boolean()]);
+
+    expectTypeOf(schema.validate)
+        .parameter(0)
+        .toEqualTypeOf<[string, number, boolean]>();
+});
+
+test('Types - validate().object matches tuple type', () => {
+    const schema = tuple([string(), number(), boolean()]);
+    const { object: res } = schema.validate(['hello', 42, true]);
+    if (res) {
+        expectTypeOf(res).toEqualTypeOf<[string, number, boolean]>();
+    }
+});
+
+test('Types - optional tuple infers union with undefined', () => {
+    const schema = tuple([string(), number()]).optional();
+    const val: InferType<typeof schema> = undefined;
+
+    expectTypeOf(val).toMatchTypeOf<[string, number] | undefined>();
+});
+
+test('Types - tuple with rest infers variadic tail', () => {
+    const schema = tuple([string(), number()]).rest(boolean());
+    const val: InferType<typeof schema> = ['hello', 42, true, false];
+
+    expectTypeOf(val).toEqualTypeOf<[string, number, ...boolean[]]>();
+});
+
+test('Types - validate() parameter with rest schema', () => {
+    const schema = tuple([string()]).rest(number());
+
+    expectTypeOf(schema.validate)
+        .parameter(0)
+        .toEqualTypeOf<[string, ...number[]]>();
+});
+
+test('Types - hasType() overrides inferred type', () => {
+    const schema = tuple([string()]).hasType<[string, string]>();
+    const val: InferType<typeof schema> = ['a', 'b'];
+
+    expectTypeOf(val).toEqualTypeOf<[string, string]>();
+});
+
+test('Types - default() makes schema non-optional', () => {
+    const schema = tuple([string(), number()])
+        .optional()
+        .default(() => ['', 0] as [string, number]);
+
+    // After .default, result is the base type (not | undefined)
+    expectTypeOf(schema.validate)
+        .parameter(0)
+        .toEqualTypeOf<[string, number]>();
+});
+
+test('Types - empty tuple has type []', () => {
+    const schema = tuple([]);
+    const val: InferType<typeof schema> = [];
+
+    expectTypeOf(val).toEqualTypeOf<[]>();
+});
+
+// ---------------------------------------------------------------------------
+// Instantiation guards
+// ---------------------------------------------------------------------------
+
+test('TupleSchemaBuilder is a SchemaBuilder', () => {
+    const schema = tuple([string(), number()]);
+    expect(schema).toBeInstanceOf(TupleSchemaBuilder);
+});
+
+// ---------------------------------------------------------------------------
+// Valid input tests
+// ---------------------------------------------------------------------------
+
+test('Valid - matching types pass', async () => {
+    const schema = tuple([string(), number(), boolean()]);
+    const { valid, errors, object: res } = schema.validate(['hello', 42, true]);
+    expect(valid).toEqual(true);
+    expect(errors).toBeUndefined();
+    expect(res).toEqual(['hello', 42, true]);
+});
+
+test('Valid - async matches sync for valid input', async () => {
+    const schema = tuple([string(), number(), boolean()]);
+    const { valid, object: res } = await schema.validateAsync([
+        'hello',
+        42,
+        true
+    ]);
+    expect(valid).toEqual(true);
+    expect(res).toEqual(['hello', 42, true]);
+});
+
+test('Valid - single-element tuple', () => {
+    const schema = tuple([string()]);
+    const { valid, object: res } = schema.validate(['hello']);
+    expect(valid).toEqual(true);
+    expect(res).toEqual(['hello']);
+});
+
+test('Valid - empty tuple', () => {
+    const schema = tuple([]);
+    const { valid } = schema.validate([] as any);
+    expect(valid).toEqual(true);
+});
+
+// ---------------------------------------------------------------------------
+// Invalid input tests
+// ---------------------------------------------------------------------------
+
+test('Invalid - too few elements', () => {
+    const schema = tuple([string(), number(), boolean()]);
+    const { valid, errors } = schema.validate(['hello', 42] as any);
+    expect(valid).toEqual(false);
+    expect(Array.isArray(errors) && errors.length > 0).toEqual(true);
+    expect(errors![0].message).toMatch(/3/);
+});
+
+test('Invalid - too many elements without rest', () => {
+    const schema = tuple([string(), number()]);
+    const { valid, errors } = schema.validate(['hello', 42, 'extra'] as any);
+    expect(valid).toEqual(false);
+    expect(Array.isArray(errors) && errors.length > 0).toEqual(true);
+});
+
+test('Invalid - wrong type at position 0', () => {
+    const schema = tuple([string(), number()]);
+    const { valid, errors } = schema.validate([123, 42] as any);
+    expect(valid).toEqual(false);
+    expect(Array.isArray(errors) && errors.length > 0).toEqual(true);
+});
+
+test('Invalid - wrong type at position 1', () => {
+    const schema = tuple([string(), number()]);
+    const { valid, errors } = schema.validate(['hello', 'oops'] as any);
+    expect(valid).toEqual(false);
+    expect(Array.isArray(errors) && errors.length > 0).toEqual(true);
+});
+
+test('Invalid - not an array', () => {
+    const schema = tuple([string(), number()]);
+    const { valid, errors } = schema.validate('not-an-array' as any);
+    expect(valid).toEqual(false);
+    expect(Array.isArray(errors) && errors.length > 0).toEqual(true);
+});
+
+test('Invalid - null on required schema', () => {
+    const schema = tuple([string(), number()]);
+    const { valid, errors } = schema.validate(null as any);
+    expect(valid).toEqual(false);
+    expect(Array.isArray(errors) && errors.length > 0).toEqual(true);
+});
+
+test('Invalid - undefined on required schema', () => {
+    const schema = tuple([string(), number()]);
+    const { valid, errors } = schema.validate(undefined as any);
+    expect(valid).toEqual(false);
+    expect(Array.isArray(errors) && errors.length > 0).toEqual(true);
+});
+
+test('Invalid - async mirrors sync for invalid', async () => {
+    const schema = tuple([string(), number()]);
+    const { valid, errors } = await schema.validateAsync([
+        'hello',
+        'oops'
+    ] as any);
+    expect(valid).toEqual(false);
+    expect(Array.isArray(errors) && errors.length > 0).toEqual(true);
+});
+
+// ---------------------------------------------------------------------------
+// Optional / required behaviour
+// ---------------------------------------------------------------------------
+
+test('Optional - null is valid', () => {
+    const schema = tuple([string(), number()]).optional();
+    const { valid, object: res } = schema.validate(null as any);
+    expect(valid).toEqual(true);
+    expect(res).toEqual(null);
+});
+
+test('Optional - undefined is valid', () => {
+    const schema = tuple([string(), number()]).optional();
+    const { valid, object: res } = schema.validate(undefined as any);
+    expect(valid).toEqual(true);
+    expect(res).toEqual(undefined);
+});
+
+test('Optional - valid tuple still validates element types', () => {
+    const schema = tuple([string(), number()]).optional();
+    const { valid, errors } = schema.validate([123, 'bad'] as any);
+    expect(valid).toEqual(false);
+    expect(Array.isArray(errors) && errors.length > 0).toEqual(true);
+});
+
+test('Optional → required - immutability', () => {
+    const optional = tuple([string()]).optional();
+    const required = optional.required();
+    expect(optional === (required as any)).toEqual(false);
+
+    const { valid: optValid } = optional.validate(undefined as any);
+    expect(optValid).toEqual(true);
+
+    const { valid: reqValid } = required.validate(undefined as any);
+    expect(reqValid).toEqual(false);
+});
+
+// ---------------------------------------------------------------------------
+// Default value
+// ---------------------------------------------------------------------------
+
+test('Default - replaces undefined', () => {
+    const schema = tuple([string(), number()]).default(() => ['x', 0]);
+    const { valid, object: res } = schema.validate(undefined as any);
+    expect(valid).toEqual(true);
+    expect(res).toEqual(['x', 0]);
+});
+
+test('Default - does not affect explicit value', () => {
+    const schema = tuple([string(), number()]).default(() => ['x', 0]);
+    const { valid, object: res } = schema.validate(['hello', 42]);
+    expect(valid).toEqual(true);
+    expect(res).toEqual(['hello', 42]);
+});
+
+test('clearDefault - removes default', () => {
+    const withDefault = tuple([string()]).default(() => ['x']);
+    const cleared = withDefault.clearDefault();
+    expect(withDefault === (cleared as any)).toEqual(false);
+
+    const { valid } = cleared.validate(undefined as any);
+    expect(valid).toEqual(false);
+});
+
+// ---------------------------------------------------------------------------
+// rest() behaviour
+// ---------------------------------------------------------------------------
+
+test('rest() - extra elements accepted', () => {
+    const schema = tuple([string(), number()]).rest(boolean());
+    const { valid, object: res } = schema.validate(['hello', 42, true, false]);
+    expect(valid).toEqual(true);
+    expect(res).toEqual(['hello', 42, true, false]);
+});
+
+test('rest() - minimum required elements still enforced', () => {
+    const schema = tuple([string(), number()]).rest(boolean());
+    const { valid } = schema.validate(['hello'] as any);
+    expect(valid).toEqual(false);
+});
+
+test('rest() - wrong type in rest section fails', () => {
+    const schema = tuple([string(), number()]).rest(boolean());
+    const { valid, errors } = schema.validate(['hello', 42, 'notBool'] as any);
+    expect(valid).toEqual(false);
+    expect(Array.isArray(errors) && errors.length > 0).toEqual(true);
+});
+
+test('rest() - zero extra elements valid', () => {
+    const schema = tuple([string(), number()]).rest(boolean());
+    const { valid } = schema.validate(['hello', 42]);
+    expect(valid).toEqual(true);
+});
+
+test('clearRest() - removes rest schema, exact length required again', () => {
+    const withRest = tuple([string(), number()]).rest(boolean());
+    const cleared = withRest.clearRest();
+    expect(withRest === (cleared as any)).toEqual(false);
+
+    const { valid: withRestValid } = withRest.validate(['hello', 42, true]);
+    expect(withRestValid).toEqual(true);
+
+    const { valid: clearedValid } = cleared.validate([
+        'hello',
+        42,
+        true
+    ] as any);
+    expect(clearedValid).toEqual(false);
+});
+
+// ---------------------------------------------------------------------------
+// getNestedErrors()
+// ---------------------------------------------------------------------------
+
+test('getNestedErrors - root errors on invalid input (not array)', () => {
+    const schema = tuple([string(), number()]);
+    const { valid, getNestedErrors } = schema.validate('not-array' as any);
+
+    expect(valid).toEqual(false);
+
+    const root = getNestedErrors();
+    expect(root.errors.length).toBeGreaterThan(0);
+    expect(root.seenValue).toEqual('not-array');
+});
+
+test('getNestedErrors - root errors on valid input empty', () => {
+    const schema = tuple([string(), number()]);
+    const { valid, getNestedErrors } = schema.validate(['hello', 42]);
+
+    expect(valid).toEqual(true);
+
+    const root = getNestedErrors();
+    expect(root.errors.length).toEqual(0);
+});
+
+test('getNestedErrors - descriptor references the schema', () => {
+    const schema = tuple([string(), number()]);
+    const { getNestedErrors } = schema.validate(['hello', 42]);
+
+    const root = getNestedErrors();
+    expect(root.descriptor.getSchema()).toBe(schema);
+});
+
+test('getNestedErrors - per-position errors with doNotStopOnFirstError', () => {
+    const schema = tuple([string(), number(), boolean()]);
+    const { valid, getNestedErrors } = schema.validate(
+        [123, 'bad', true] as any,
+        { doNotStopOnFirstError: true }
+    );
+
+    expect(valid).toEqual(false);
+
+    const positions = getNestedErrors();
+    expect(positions.length).toEqual(3);
+    // position 0: number given for string — invalid
+    expect(positions[0]!.valid).toEqual(false);
+    // position 1: string given for number — invalid
+    expect(positions[1]!.valid).toEqual(false);
+    // position 2: boolean — valid
+    expect(positions[2]!.valid).toEqual(true);
+});
+
+test('getNestedErrors - per-position valid on full match', () => {
+    const schema = tuple([string(), number(), boolean()]);
+    const { valid, getNestedErrors } = schema.validate(['hello', 42, true], {
+        doNotStopOnFirstError: true
+    });
+
+    expect(valid).toEqual(true);
+
+    const positions = getNestedErrors();
+    expect(positions.length).toEqual(3);
+    expect(positions[0]!.valid).toEqual(true);
+    expect(positions[1]!.valid).toEqual(true);
+    expect(positions[2]!.valid).toEqual(true);
+});
+
+test('getNestedErrors - object element exposes getErrorsFor', () => {
+    const schema = tuple([
+        object({ name: string().required(), age: number().required() })
+    ]);
+
+    const { valid, getNestedErrors } = schema.validate(
+        [{ name: 'Alice', age: 'bad' as any }] as any,
+        { doNotStopOnFirstError: true }
+    );
+
+    expect(valid).toEqual(false);
+
+    const positions = getNestedErrors();
+    const first = positions[0]!;
+    expect(first.valid).toEqual(false);
+    expect(typeof first.getErrorsFor).toEqual('function');
+
+    const ageErrors = (first as any).getErrorsFor((t: any) => t.age);
+    expect(ageErrors.errors.length).toBeGreaterThan(0);
+});
+
+test('getNestedErrors - union element exposes getNestedErrors', () => {
+    const schema = tuple([union(string()).or(number())]);
+
+    const { valid, getNestedErrors } = schema.validate([true as any] as any, {
+        doNotStopOnFirstError: true
+    });
+
+    expect(valid).toEqual(false);
+
+    const positions = getNestedErrors();
+    expect(positions[0]!.valid).toEqual(false);
+    expect(typeof (positions[0] as any).getNestedErrors).toEqual('function');
+});
+
+test('getNestedErrors - rest elements included in positions', () => {
+    const schema = tuple([string()]).rest(number());
+
+    const { valid, getNestedErrors } = schema.validate(
+        ['hello', 42, 99] as any,
+        { doNotStopOnFirstError: true }
+    );
+
+    expect(valid).toEqual(true);
+
+    const positions = getNestedErrors();
+    expect(positions.length).toEqual(3);
+    expect(positions[0]!.valid).toEqual(true);
+    expect(positions[1]!.valid).toEqual(true);
+    expect(positions[2]!.valid).toEqual(true);
+});
+
+// ---------------------------------------------------------------------------
+// Immutability
+// ---------------------------------------------------------------------------
+
+test('Immutability - rest() returns new instance', () => {
+    const schema1 = tuple([string()]);
+    const schema2 = schema1.rest(number());
+    expect(schema1 === (schema2 as any)).toEqual(false);
+});
+
+test('Immutability - optional() returns new instance', () => {
+    const schema1 = tuple([string()]);
+    const schema2 = schema1.optional();
+    expect(schema1 === (schema2 as any)).toEqual(false);
+});
+
+// ---------------------------------------------------------------------------
+// introspect()
+// ---------------------------------------------------------------------------
+
+test('introspect() - exposes elements and restSchema', () => {
+    const str = string();
+    const num = number();
+    const boo = boolean();
+
+    const schema = tuple([str, num]).rest(boo);
+    const info = schema.introspect();
+
+    expect(info.elements).toEqual([str, num]);
+    expect(info.restSchema).toBe(boo);
+    expect(info.type).toEqual('tuple');
+});
+
+test('introspect() - restSchema is undefined without rest()', () => {
+    const schema = tuple([string()]);
+    const info = schema.introspect();
+    expect(info.restSchema).toBeUndefined();
+});

--- a/libs/schema/src/builders/TupleSchemaBuilder.ts
+++ b/libs/schema/src/builders/TupleSchemaBuilder.ts
@@ -1,0 +1,921 @@
+import type {
+    ObjectSchemaBuilder,
+    ObjectSchemaValidationResult
+} from './ObjectSchemaBuilder.js';
+import {
+    type BRAND,
+    createHybridErrorArray,
+    type InferType,
+    type NestedValidationResult,
+    type PropertyDescriptor,
+    SchemaBuilder,
+    SYMBOL_SCHEMA_PROPERTY_DESCRIPTOR,
+    type ValidationContext,
+    type ValidationErrorMessageProvider,
+    type ValidationResult
+} from './SchemaBuilder.js';
+import type {
+    UnionSchemaBuilder,
+    UnionSchemaValidationResult
+} from './UnionSchemaBuilder.js';
+
+/**
+ * Maps a tuple of schema builders to a tuple of their per-position
+ * validation result types.
+ * Union schema elements get `UnionSchemaValidationResult`,
+ * object schema elements get `ObjectSchemaValidationResult`,
+ * other types get `ValidationResult`.
+ */
+export type TupleElementValidationResults<
+    TElements extends readonly SchemaBuilder<any, any, any>[]
+> = {
+    [K in keyof TElements]: TElements[K] extends UnionSchemaBuilder<
+        infer UOptions extends readonly SchemaBuilder<any, any, any>[],
+        any,
+        any
+    >
+        ? UnionSchemaValidationResult<InferType<TElements[K]>, UOptions>
+        : TElements[K] extends ObjectSchemaBuilder<any, any, any, any, any>
+          ? ObjectSchemaValidationResult<InferType<TElements[K]>, TElements[K]>
+          : ValidationResult<InferType<TElements[K]>>;
+};
+
+/**
+ * Validation result type returned by `TupleSchemaBuilder.validate()`.
+ * Extends `ValidationResult` with `getNestedErrors` for root-level tuple
+ * errors and per-position validation results.
+ */
+export type TupleSchemaValidationResult<
+    TResult,
+    TElements extends readonly SchemaBuilder<any, any, any>[]
+> = ValidationResult<TResult> & {
+    /**
+     * Returns root-level tuple validation errors combined with
+     * per-position validation results.
+     * The returned value has both `NestedValidationResult` properties
+     * (`errors`, `isValid`, `descriptor`, `seenValue`) and indexed
+     * position results (`[0]`, `[1]`, etc.).
+     */
+    getNestedErrors(): TupleElementValidationResults<TElements> &
+        NestedValidationResult<any, any, any>;
+};
+
+type TupleSchemaBuilderCreateProps<
+    TElements extends readonly SchemaBuilder<any, any, any>[],
+    TRestSchema extends SchemaBuilder<any, any, any> | undefined = undefined,
+    R extends boolean = true
+> = Partial<
+    ReturnType<
+        TupleSchemaBuilder<
+            TElements,
+            R,
+            undefined,
+            false,
+            {},
+            TRestSchema
+        >['introspect']
+    >
+>;
+
+/**
+ * Fixed-length array schema builder with per-position type validation.
+ * Similar to TypeScript's tuple types — each element at a specific array index
+ * is validated against its own schema.
+ *
+ * Use it when you need to validate function arguments, CSV rows, coordinate
+ * pairs, structured event payloads, or any other fixed-structure array.
+ *
+ * **NOTE** this class is exported only to give opportunity to extend it
+ * by inheriting. It is not recommended to create an instance of this class
+ * directly. Use {@link tuple | tuple()} function instead.
+ *
+ * @example
+ * ```ts
+ * const schema = tuple([string(), number(), boolean()]);
+ * // Inferred TypeScript type: [string, number, boolean]
+ *
+ * schema.validate(['hello', 42, true]);
+ * // result.valid === true
+ * // result.object === ['hello', 42, true]
+ *
+ * schema.validate(['hello', 42]);
+ * // result.valid === false  (too few elements)
+ *
+ * schema.validate(['hello', 'oops', true]);
+ * // result.valid === false  (wrong type at position 1)
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Tuple with variadic rest elements
+ * const schema = tuple([string(), number()]).rest(boolean());
+ * // Inferred TypeScript type: [string, number, ...boolean[]]
+ *
+ * schema.validate(['hello', 42, true, false]);
+ * // result.valid === true — any number of extra booleans allowed
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Nested tuple combining with object schemas
+ * const point = tuple([number(), number()]);
+ * const segment = tuple([point, point]);
+ *
+ * segment.validate([[0, 0], [10, 20]]);
+ * // result.valid === true
+ * ```
+ *
+ * @see {@link tuple}
+ */
+export class TupleSchemaBuilder<
+    TElements extends readonly SchemaBuilder<any, any, any>[],
+    TRequired extends boolean = true,
+    TExplicitType = undefined,
+    THasDefault extends boolean = false,
+    TExtensions = {},
+    TRestSchema extends SchemaBuilder<any, any, any> | undefined = undefined,
+    TResult = TExplicitType extends undefined
+        ? TRestSchema extends SchemaBuilder<any, any, any>
+            ? [
+                  ...{ [K in keyof TElements]: InferType<TElements[K]> },
+                  ...Array<InferType<TRestSchema>>
+              ]
+            : { [K in keyof TElements]: InferType<TElements[K]> }
+        : TExplicitType
+> extends SchemaBuilder<TResult, TRequired, THasDefault, TExtensions> {
+    #elements!: TElements;
+    #restSchema: (TRestSchema & SchemaBuilder<any, any, any>) | undefined;
+
+    /**
+     * @hidden
+     */
+    public static create(props: TupleSchemaBuilderCreateProps<any, any, any>) {
+        return new TupleSchemaBuilder({
+            type: 'tuple',
+            ...props
+        } as any);
+    }
+
+    protected constructor(
+        props: TupleSchemaBuilderCreateProps<TElements, TRestSchema, TRequired>
+    ) {
+        super(props as any);
+
+        if (Array.isArray(props.elements)) {
+            this.#elements = props.elements as TElements;
+        } else {
+            this.#elements = [] as unknown as TElements;
+        }
+
+        if (props.restSchema instanceof SchemaBuilder) {
+            this.#restSchema = props.restSchema as any;
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public hasType<T>(
+        _notUsed?: T
+    ): TupleSchemaBuilder<
+        TElements,
+        true,
+        T,
+        THasDefault,
+        TExtensions,
+        TRestSchema
+    > &
+        TExtensions {
+        return this.createFromProps({
+            ...this.introspect()
+        } as any) as any;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public clearHasType(): TupleSchemaBuilder<
+        TElements,
+        TRequired,
+        undefined,
+        THasDefault,
+        TExtensions,
+        TRestSchema
+    > &
+        TExtensions {
+        return this.createFromProps({
+            ...this.introspect()
+        } as any) as any;
+    }
+
+    #getLengthError(arr: any[]): string | null {
+        if (arr.length < this.#elements.length) {
+            const n = this.#elements.length;
+            return `expected a tuple with at least ${n} element${n === 1 ? '' : 's'}, got ${arr.length}`;
+        }
+        if (
+            !(this.#restSchema instanceof SchemaBuilder) &&
+            arr.length !== this.#elements.length
+        ) {
+            const n = this.#elements.length;
+            return `expected a tuple of exactly ${n} element${n === 1 ? '' : 's'}, got ${arr.length}`;
+        }
+        return null;
+    }
+
+    #createValidationSetup(
+        object: TResult,
+        superResult: ReturnType<TupleSchemaBuilder<any, any>['preValidateSync']>
+    ) {
+        const {
+            valid,
+            context: prevalidationContext,
+            errors,
+            transaction: preValidationTransaction
+        } = superResult;
+
+        const selfDescriptor: PropertyDescriptor<any, any, any> = {
+            [SYMBOL_SCHEMA_PROPERTY_DESCRIPTOR]: {
+                setValue: () => false,
+                getValue: (obj: any) => ({
+                    success: true,
+                    value: obj
+                }),
+                getSchema: () => this,
+                parent: undefined
+            }
+        };
+
+        const rootErrors: string[] = [];
+        const elementResults = createHybridErrorArray(
+            [] as any[],
+            () => object,
+            () => rootErrors,
+            () => selfDescriptor[SYMBOL_SCHEMA_PROPERTY_DESCRIPTOR]
+        );
+        const getNestedErrors = (() => elementResults) as any;
+
+        if (!valid) {
+            rootErrors.push(
+                ...(errors || []).map((e: any) => e.message || String(e))
+            );
+            return {
+                needsElementValidation: false as const,
+                result: {
+                    valid,
+                    errors,
+                    getNestedErrors
+                } as TupleSchemaValidationResult<TResult, TElements>
+            };
+        }
+
+        const {
+            object: { validatedObject: objToValidate }
+        } = preValidationTransaction!;
+
+        if (
+            (typeof objToValidate === 'undefined' || objToValidate === null) &&
+            this.isRequired === false
+        ) {
+            return {
+                needsElementValidation: false as const,
+                result: {
+                    valid: true,
+                    object: objToValidate,
+                    getNestedErrors
+                } as TupleSchemaValidationResult<TResult, TElements>
+            };
+        }
+
+        if (!Array.isArray(objToValidate)) {
+            rootErrors.push('array expected');
+            return {
+                needsElementValidation: false as const,
+                result: {
+                    valid: false,
+                    errors: [{ message: 'array expected' }],
+                    getNestedErrors
+                } as TupleSchemaValidationResult<TResult, TElements>
+            };
+        }
+
+        return {
+            needsElementValidation: true as const,
+            objToValidate,
+            prevalidationContext,
+            getNestedErrors,
+            elementResults,
+            rootErrors
+        };
+    }
+
+    #assembleDoNotStopResults(
+        results: any[],
+        elementResults: any,
+        getNestedErrors: any
+    ) {
+        let allValid = true;
+
+        for (let i = 0; i < results.length; i++) {
+            if (!results[i]?.valid) {
+                allValid = false;
+            }
+            elementResults[i] = results[i] as any;
+        }
+
+        return Object.assign(
+            {
+                valid: allValid,
+                getNestedErrors
+            },
+            allValid
+                ? {}
+                : {
+                      errors: results
+                          .map(r => r?.errors)
+                          .filter(r => r)
+                          .flatMap(e =>
+                              e?.map((r: any) => ({
+                                  ...r
+                              }))
+                          ) as any
+                  },
+            allValid
+                ? {
+                      object: results.map(r => r?.object)
+                  }
+                : {}
+        ) as any;
+    }
+
+    /**
+     * Performs synchronous validation of the schema over `object`.
+     * Throws if any preprocessor, validator, or error message provider returns a Promise.
+     * @param context Optional `ValidationContext` settings.
+     */
+    public validate(
+        object: TResult,
+        context?: ValidationContext
+    ): TupleSchemaValidationResult<TResult, TElements> {
+        // Fast path: no preprocessors/validators, stop-on-first-error mode
+        if (this.canSkipPreValidation && !context?.doNotStopOnFirstError) {
+            // Handle undefined / null
+            if (typeof object === 'undefined' || object === null) {
+                if (typeof object === 'undefined' && this.hasDefault) {
+                    object = this.resolveDefaultValue();
+                } else if (!this.isRequired) {
+                    const self = this;
+                    return {
+                        valid: true,
+                        object,
+                        getNestedErrors() {
+                            return self
+                                .#validateTupleFull(object, context)
+                                .getNestedErrors();
+                        }
+                    } as any;
+                } else {
+                    return this.#validateTupleFull(object, context);
+                }
+            }
+
+            if (!Array.isArray(object)) {
+                return this.#validateTupleFull(object, context);
+            }
+
+            const lengthError = this.#getLengthError(object as any[]);
+            if (lengthError) {
+                const self = this;
+                return {
+                    valid: false,
+                    errors: [{ message: lengthError }],
+                    getNestedErrors() {
+                        return self
+                            .#validateTupleFull(object, context)
+                            .getNestedErrors();
+                    }
+                } as any;
+            }
+
+            const resultArray = new Array((object as any[]).length);
+
+            for (let i = 0; i < this.#elements.length; i++) {
+                const result = this.#elements[i].validate((object as any)[i]);
+                if (!result.valid) {
+                    const self = this;
+                    return {
+                        valid: false,
+                        errors:
+                            result.errors && result.errors.length > 0
+                                ? [result.errors[0]]
+                                : [],
+                        getNestedErrors() {
+                            return self
+                                .#validateTupleFull(object, context)
+                                .getNestedErrors();
+                        }
+                    } as any;
+                }
+                resultArray[i] = result.object;
+            }
+
+            if (this.#restSchema instanceof SchemaBuilder) {
+                for (
+                    let i = this.#elements.length;
+                    i < (object as any[]).length;
+                    i++
+                ) {
+                    const result = this.#restSchema.validate(
+                        (object as any)[i]
+                    );
+                    if (!result.valid) {
+                        const self = this;
+                        return {
+                            valid: false,
+                            errors:
+                                result.errors && result.errors.length > 0
+                                    ? [result.errors[0]]
+                                    : [],
+                            getNestedErrors() {
+                                return self
+                                    .#validateTupleFull(object, context)
+                                    .getNestedErrors();
+                            }
+                        } as any;
+                    }
+                    resultArray[i] = result.object;
+                }
+            }
+
+            const self = this;
+            return {
+                valid: true,
+                object: resultArray as TResult,
+                getNestedErrors() {
+                    return self
+                        .#validateTupleFull(object, context)
+                        .getNestedErrors();
+                }
+            } as any;
+        }
+
+        return this.#validateTupleFull(object, context);
+    }
+
+    /**
+     * Full validation path with complete setup, error handling, and nested
+     * error support.
+     */
+    #validateTupleFull(
+        object: TResult,
+        context?: ValidationContext
+    ): TupleSchemaValidationResult<TResult, TElements> {
+        const setup = this.#createValidationSetup(
+            object,
+            this.preValidateSync(object, context)
+        );
+
+        if (!setup.needsElementValidation) return setup.result;
+
+        const {
+            objToValidate,
+            prevalidationContext,
+            getNestedErrors,
+            elementResults,
+            rootErrors
+        } = setup;
+
+        const lengthError = this.#getLengthError(objToValidate);
+        if (lengthError) {
+            rootErrors.push(lengthError);
+            return {
+                valid: false,
+                errors: [{ message: lengthError }],
+                getNestedErrors
+            };
+        }
+
+        const totalLength =
+            this.#restSchema instanceof SchemaBuilder
+                ? objToValidate.length
+                : this.#elements.length;
+
+        if (prevalidationContext.doNotStopOnFirstError) {
+            const results: any[] = new Array(totalLength);
+
+            for (let i = 0; i < this.#elements.length; i++) {
+                results[i] = this.#elements[i].validate(objToValidate[i], {
+                    ...prevalidationContext
+                });
+            }
+
+            if (this.#restSchema instanceof SchemaBuilder) {
+                for (
+                    let i = this.#elements.length;
+                    i < objToValidate.length;
+                    i++
+                ) {
+                    results[i] = this.#restSchema.validate(objToValidate[i], {
+                        ...prevalidationContext
+                    });
+                }
+            }
+
+            return this.#assembleDoNotStopResults(
+                results,
+                elementResults,
+                getNestedErrors
+            );
+        } else {
+            const resultArray = new Array(totalLength);
+
+            for (let i = 0; i < this.#elements.length; i++) {
+                const result = this.#elements[i].validate(objToValidate[i], {
+                    ...prevalidationContext
+                });
+                elementResults[i] = result as any;
+                if (result.valid) {
+                    resultArray[i] = result.object;
+                } else {
+                    return {
+                        valid: false,
+                        errors:
+                            Array.isArray(result.errors) &&
+                            result.errors.length > 0
+                                ? [result.errors[0]]
+                                : [],
+                        getNestedErrors
+                    };
+                }
+            }
+
+            if (this.#restSchema instanceof SchemaBuilder) {
+                for (
+                    let i = this.#elements.length;
+                    i < objToValidate.length;
+                    i++
+                ) {
+                    const result = this.#restSchema.validate(objToValidate[i], {
+                        ...prevalidationContext
+                    });
+                    elementResults[i] = result as any;
+                    if (result.valid) {
+                        resultArray[i] = result.object;
+                    } else {
+                        return {
+                            valid: false,
+                            errors:
+                                Array.isArray(result.errors) &&
+                                result.errors.length > 0
+                                    ? [result.errors[0]]
+                                    : [],
+                            getNestedErrors
+                        };
+                    }
+                }
+            }
+
+            return {
+                valid: true,
+                object: resultArray as TResult,
+                getNestedErrors
+            };
+        }
+    }
+
+    /**
+     * Performs async validation of the schema over `object`.
+     * Supports async preprocessors, validators, and error message providers.
+     * @param context Optional `ValidationContext` settings.
+     */
+    public async validateAsync(
+        object: TResult,
+        context?: ValidationContext
+    ): Promise<TupleSchemaValidationResult<TResult, TElements>> {
+        const setup = this.#createValidationSetup(
+            object,
+            await super.preValidateAsync(object, context)
+        );
+
+        if (!setup.needsElementValidation) return setup.result;
+
+        const {
+            objToValidate,
+            prevalidationContext,
+            getNestedErrors,
+            elementResults,
+            rootErrors
+        } = setup;
+
+        const lengthError = this.#getLengthError(objToValidate);
+        if (lengthError) {
+            rootErrors.push(lengthError);
+            return {
+                valid: false,
+                errors: [{ message: lengthError }],
+                getNestedErrors
+            };
+        }
+
+        const totalLength =
+            this.#restSchema instanceof SchemaBuilder
+                ? objToValidate.length
+                : this.#elements.length;
+
+        if (prevalidationContext.doNotStopOnFirstError) {
+            const promises: Promise<any>[] = new Array(totalLength);
+
+            for (let i = 0; i < this.#elements.length; i++) {
+                promises[i] = this.#elements[i].validateAsync(
+                    objToValidate[i],
+                    { ...prevalidationContext }
+                );
+            }
+
+            if (this.#restSchema instanceof SchemaBuilder) {
+                for (
+                    let i = this.#elements.length;
+                    i < objToValidate.length;
+                    i++
+                ) {
+                    promises[i] = this.#restSchema.validateAsync(
+                        objToValidate[i],
+                        { ...prevalidationContext }
+                    );
+                }
+            }
+
+            const results = await Promise.all(promises);
+            return this.#assembleDoNotStopResults(
+                results,
+                elementResults,
+                getNestedErrors
+            );
+        } else {
+            const resultArray = new Array(totalLength);
+
+            for (let i = 0; i < this.#elements.length; i++) {
+                const result = await this.#elements[i].validateAsync(
+                    objToValidate[i],
+                    { ...prevalidationContext }
+                );
+                elementResults[i] = result as any;
+                if (result.valid) {
+                    resultArray[i] = result.object;
+                } else {
+                    return {
+                        valid: false,
+                        errors:
+                            Array.isArray(result.errors) &&
+                            result.errors.length > 0
+                                ? [result.errors[0]]
+                                : [],
+                        getNestedErrors
+                    };
+                }
+            }
+
+            if (this.#restSchema instanceof SchemaBuilder) {
+                for (
+                    let i = this.#elements.length;
+                    i < objToValidate.length;
+                    i++
+                ) {
+                    const result = await this.#restSchema.validateAsync(
+                        objToValidate[i],
+                        { ...prevalidationContext }
+                    );
+                    elementResults[i] = result as any;
+                    if (result.valid) {
+                        resultArray[i] = result.object;
+                    } else {
+                        return {
+                            valid: false,
+                            errors:
+                                Array.isArray(result.errors) &&
+                                result.errors.length > 0
+                                    ? [result.errors[0]]
+                                    : [],
+                            getNestedErrors
+                        };
+                    }
+                }
+            }
+
+            return {
+                valid: true,
+                object: resultArray as TResult,
+                getNestedErrors
+            };
+        }
+    }
+
+    /**
+     * @hidden
+     */
+    protected createFromProps<TReq extends boolean>(
+        props: TupleSchemaBuilderCreateProps<TElements, TRestSchema, TReq>
+    ): this {
+        return TupleSchemaBuilder.create(props as any) as any;
+    }
+
+    /**
+     * @hidden
+     */
+    public required(
+        errorMessage?: ValidationErrorMessageProvider
+    ): TupleSchemaBuilder<
+        TElements,
+        true,
+        TExplicitType,
+        THasDefault,
+        TExtensions,
+        TRestSchema
+    > &
+        TExtensions {
+        return super.required(errorMessage);
+    }
+
+    /**
+     * @hidden
+     */
+    public optional(): TupleSchemaBuilder<
+        TElements,
+        false,
+        TExplicitType,
+        THasDefault,
+        TExtensions,
+        TRestSchema
+    > &
+        TExtensions {
+        return super.optional();
+    }
+
+    /**
+     * @hidden
+     */
+    public default(
+        value: TResult | (() => TResult)
+    ): TupleSchemaBuilder<
+        TElements,
+        true,
+        TExplicitType,
+        true,
+        TExtensions,
+        TRestSchema
+    > &
+        TExtensions {
+        return super.default(value) as any;
+    }
+
+    /**
+     * @hidden
+     */
+    public clearDefault(): TupleSchemaBuilder<
+        TElements,
+        TRequired,
+        TExplicitType,
+        false,
+        TExtensions,
+        TRestSchema
+    > &
+        TExtensions {
+        return super.clearDefault() as any;
+    }
+
+    /**
+     * @hidden
+     */
+    public brand<TBrand extends string | symbol>(
+        _name?: TBrand
+    ): TupleSchemaBuilder<
+        TElements,
+        TRequired,
+        TResult & { readonly [K in BRAND]: TBrand },
+        THasDefault,
+        TExtensions,
+        TRestSchema
+    > &
+        TExtensions {
+        return super.brand(_name);
+    }
+
+    public introspect() {
+        return {
+            ...super.introspect(),
+            /**
+             * Per-position element schemas defining the fixed tuple structure.
+             */
+            elements: this.#elements,
+            /**
+             * Optional schema for elements beyond the fixed positions.
+             * When set, additional elements are validated against this schema.
+             * Mirrors TypeScript's rest element syntax: `[string, number, ...boolean[]]`.
+             */
+            restSchema: this.#restSchema
+        };
+    }
+
+    /**
+     * Sets a schema that all elements beyond the fixed positions must satisfy.
+     * Mirrors TypeScript's variadic tuple tail: `[string, number, ...boolean[]]`.
+     *
+     * When set, the tuple length must be at least equal to the number of fixed
+     * elements, and any additional elements are validated against `schema`.
+     * When not set, the tuple length must be exactly equal to the fixed count.
+     *
+     * @param schema Schema that extra array elements must satisfy.
+     *
+     * @example
+     * ```ts
+     * const schema = tuple([string(), number()]).rest(boolean());
+     * // Inferred TypeScript type: [string, number, ...boolean[]]
+     *
+     * schema.validate(['hello', 42]);               // valid
+     * schema.validate(['hello', 42, true]);          // valid
+     * schema.validate(['hello', 42, true, false]);   // valid
+     * schema.validate(['hello', 42, 'extra']);       // invalid — 'extra' not boolean
+     * ```
+     */
+    public rest<TSchema extends SchemaBuilder<any, any, any>>(
+        schema: TSchema
+    ): TupleSchemaBuilder<
+        TElements,
+        TRequired,
+        TExplicitType,
+        THasDefault,
+        TExtensions,
+        TSchema
+    > &
+        TExtensions {
+        return TupleSchemaBuilder.create({
+            ...this.introspect(),
+            restSchema: schema
+        } as any) as any;
+    }
+
+    /**
+     * Removes the rest schema set by `rest()`. After this call, the tuple
+     * length must be exactly equal to the number of fixed element schemas.
+     */
+    public clearRest(): TupleSchemaBuilder<
+        TElements,
+        TRequired,
+        TExplicitType,
+        THasDefault,
+        TExtensions,
+        undefined
+    > &
+        TExtensions {
+        return TupleSchemaBuilder.create({
+            ...this.introspect(),
+            restSchema: undefined
+        } as any) as any;
+    }
+}
+
+/**
+ * Creates a fixed-length array schema (tuple) where each element at a
+ * specific index is validated against its own schema.
+ *
+ * @param elements Array of per-position schemas. The length of this array
+ *   determines the required tuple length (unless `.rest()` is used).
+ *
+ * @example
+ * ```ts
+ * import { tuple, string, number, boolean } from '@cleverbrush/schema';
+ *
+ * const schema = tuple([string(), number(), boolean()]);
+ * // Inferred TypeScript type: [string, number, boolean]
+ *
+ * schema.validate(['hello', 42, true]);     // valid
+ * schema.validate(['hello', 42]);           // invalid — too few elements
+ * schema.validate(['hello', 'oops', true]); // invalid — wrong type at [1]
+ * ```
+ *
+ * @example
+ * ```ts
+ * // 2-D coordinate pair
+ * const point = tuple([number(), number()]);
+ * const result = point.validate([10.5, 20.3]);
+ * // result.valid === true
+ * // result.object === [10.5, 20.3]
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Optional tuple with default value
+ * const schema = tuple([string(), number()])
+ *     .optional()
+ *     .default(() => ['', 0]);
+ * ```
+ */
+export const tuple = <
+    const TElements extends readonly SchemaBuilder<any, any, any>[]
+>(
+    elements: [...TElements]
+) =>
+    TupleSchemaBuilder.create({
+        isRequired: true,
+        elements
+    }) as unknown as TupleSchemaBuilder<TElements, true>;

--- a/libs/schema/src/core.ts
+++ b/libs/schema/src/core.ts
@@ -41,6 +41,11 @@ export {
 } from './builders/SchemaBuilder.js';
 export { StringSchemaBuilder, string } from './builders/StringSchemaBuilder.js';
 export type {
+    TupleElementValidationResults,
+    TupleSchemaValidationResult
+} from './builders/TupleSchemaBuilder.js';
+export { TupleSchemaBuilder, tuple } from './builders/TupleSchemaBuilder.js';
+export type {
     OptionValidationResults,
     UnionSchemaValidationResult
 } from './builders/UnionSchemaBuilder.js';

--- a/libs/schema/src/extension.ts
+++ b/libs/schema/src/extension.ts
@@ -77,6 +77,7 @@ import { NumberSchemaBuilder, number } from './builders/NumberSchemaBuilder.js';
 import { ObjectSchemaBuilder, object } from './builders/ObjectSchemaBuilder.js';
 import type { SchemaBuilder } from './builders/SchemaBuilder.js';
 import { StringSchemaBuilder, string } from './builders/StringSchemaBuilder.js';
+import { TupleSchemaBuilder, tuple } from './builders/TupleSchemaBuilder.js';
 import { UnionSchemaBuilder, union } from './builders/UnionSchemaBuilder.js';
 
 // ---------------------------------------------------------------------------
@@ -98,6 +99,7 @@ type BuilderMap = {
     date: DateSchemaBuilder<any, any, any, any>;
     object: ObjectSchemaBuilder<any, any, any, any, any>;
     array: ArraySchemaBuilder<any, any, any, any, any, any>;
+    tuple: TupleSchemaBuilder<any, any, any, any, any, any>;
     union: UnionSchemaBuilder<any, any, any, any, any>;
     func: FunctionSchemaBuilder<any, any, any, any, any>;
     any: AnySchemaBuilder<any, any, any, any, any>;
@@ -113,6 +115,7 @@ const builderClasses: Record<BuilderTypeName, typeof SchemaBuilder> = {
     date: DateSchemaBuilder as any,
     object: ObjectSchemaBuilder as any,
     array: ArraySchemaBuilder as any,
+    tuple: TupleSchemaBuilder as any,
     union: UnionSchemaBuilder as any,
     func: FunctionSchemaBuilder as any,
     any: AnySchemaBuilder as any
@@ -126,6 +129,7 @@ const builderFactories: Record<BuilderTypeName, (...args: any[]) => any> = {
     date,
     object,
     array,
+    tuple,
     union,
     func,
     any
@@ -335,6 +339,15 @@ type ExtendedAnyFactory<TExt> = () => CleanExtended<
     TExt
 >;
 
+type ExtendedTupleFactory<TExt> = <
+    const TElements extends readonly SchemaBuilder<any, any, any>[]
+>(
+    elements: [...TElements]
+) => CleanExtended<
+    TupleSchemaBuilder<TElements, true, undefined, false, TExt>,
+    TExt
+>;
+
 /**
  * The return type of {@link withExtensions}.
  *
@@ -354,6 +367,7 @@ type WithExtensionsResult<TExts extends readonly ExtensionDescriptor<any>[]> = {
     date: ExtendedDateFactory<MergeExtensionMethods<TExts, 'date'>>;
     object: ExtendedObjectFactory<MergeExtensionMethods<TExts, 'object'>>;
     array: ExtendedArrayFactory<MergeExtensionMethods<TExts, 'array'>>;
+    tuple: ExtendedTupleFactory<MergeExtensionMethods<TExts, 'tuple'>>;
     union: ExtendedUnionFactory<MergeExtensionMethods<TExts, 'union'>>;
     func: ExtendedFuncFactory<MergeExtensionMethods<TExts, 'func'>>;
     any: ExtendedAnyFactory<MergeExtensionMethods<TExts, 'any'>>;

--- a/libs/schema/src/extensions/index.ts
+++ b/libs/schema/src/extensions/index.ts
@@ -20,6 +20,7 @@ import type { NumberSchemaBuilder } from '../builders/NumberSchemaBuilder.js';
 import type { ObjectSchemaBuilder } from '../builders/ObjectSchemaBuilder.js';
 import type { SchemaBuilder } from '../builders/SchemaBuilder.js';
 import type { StringSchemaBuilder } from '../builders/StringSchemaBuilder.js';
+import type { TupleSchemaBuilder } from '../builders/TupleSchemaBuilder.js';
 import type { UnionSchemaBuilder } from '../builders/UnionSchemaBuilder.js';
 import type { HiddenExtensionMethods } from '../extension.js';
 import { withExtensions } from '../extension.js';
@@ -31,6 +32,7 @@ import type {
     DateBuiltinExtensions,
     FuncBuiltinExtensions,
     ObjectBuiltinExtensions,
+    TupleBuiltinExtensions,
     UnionBuiltinExtensions
 } from './nullable.js';
 import { nullableExtension } from './nullable.js';
@@ -49,6 +51,7 @@ export {
     type NullableReturn,
     nullableExtension,
     type ObjectBuiltinExtensions,
+    type TupleBuiltinExtensions,
     type UnionBuiltinExtensions
 } from './nullable.js';
 export { type NumberBuiltinExtensions, numberExtensions } from './number.js';
@@ -168,6 +171,23 @@ export type ExtendedAny = AnySchemaBuilder<
     AnyBuiltinExtensions &
     HiddenExtensionMethods;
 
+/** A `TupleSchemaBuilder` with built-in extension methods. */
+export type ExtendedTuple<
+    TElements extends readonly SchemaBuilder<
+        any,
+        any,
+        any
+    >[] = readonly SchemaBuilder<any, any, any>[]
+> = TupleSchemaBuilder<
+    TElements,
+    true,
+    undefined,
+    false,
+    TupleBuiltinExtensions<TElements>
+> &
+    TupleBuiltinExtensions<TElements> &
+    HiddenExtensionMethods;
+
 // -- Runtime factories with explicit type annotations -------------------------
 
 const s = withExtensions(
@@ -207,3 +227,8 @@ export const union: <TOptions extends SchemaBuilder<any, any, any>>(
 ) => ExtendedUnion<[TOptions]> = s.union as any;
 export const func: () => ExtendedFunc = s.func as any;
 export const any: () => ExtendedAny = s.any as any;
+export const tuple: <
+    const TElements extends readonly SchemaBuilder<any, any, any>[]
+>(
+    elements: [...TElements]
+) => ExtendedTuple<TElements> = s.tuple as any;

--- a/libs/schema/src/extensions/nullable.test.ts
+++ b/libs/schema/src/extensions/nullable.test.ts
@@ -9,6 +9,7 @@ import {
     number,
     object,
     string,
+    tuple,
     union
 } from '../index.js';
 
@@ -358,6 +359,44 @@ describe('nullable extension', () => {
 
             expect(Schema.validate({ value: 10 }).valid).toBe(true);
             expect(Schema.validate({ value: null as any }).valid).toBe(true);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // tuple().nullable()
+    // -----------------------------------------------------------------------
+    describe('tuple().nullable()', () => {
+        test('accepts a valid tuple', () => {
+            const schema = tuple([string(), number()]).nullable();
+            const result = schema.validate(['hello', 42]);
+            expect(result.valid).toBe(true);
+            expect(result.object).toEqual(['hello', 42]);
+        });
+
+        test('accepts null', () => {
+            const schema = tuple([string(), number()]).nullable();
+            const result = schema.validate(null as any);
+            expect(result.valid).toBe(true);
+            expect(result.object).toBeNull();
+        });
+
+        test('rejects undefined', () => {
+            const schema = tuple([string(), number()]).nullable();
+            const result = schema.validate(undefined as any);
+            expect(result.valid).toBe(false);
+        });
+
+        test('rejects wrong element type', () => {
+            const schema = tuple([string(), number()]).nullable();
+            const result = schema.validate(['hello', 'bad'] as any);
+            expect(result.valid).toBe(false);
+        });
+
+        test('inferred type is [string, number] | null', () => {
+            const schema = tuple([string(), number()]).nullable();
+            type T = InferType<typeof schema>;
+            expectTypeOf<T>().toMatchTypeOf<[string, number] | null>();
+            expectTypeOf<null>().toMatchTypeOf<T>();
         });
     });
 

--- a/libs/schema/src/extensions/nullable.ts
+++ b/libs/schema/src/extensions/nullable.ts
@@ -20,6 +20,7 @@ import type { NumberSchemaBuilder } from '../builders/NumberSchemaBuilder.js';
 import type { ObjectSchemaBuilder } from '../builders/ObjectSchemaBuilder.js';
 import type { SchemaBuilder } from '../builders/SchemaBuilder.js';
 import type { StringSchemaBuilder } from '../builders/StringSchemaBuilder.js';
+import type { TupleSchemaBuilder } from '../builders/TupleSchemaBuilder.js';
 import {
     type UnionSchemaBuilder,
     union
@@ -112,6 +113,26 @@ export interface AnyBuiltinExtensions {
     /** Makes this schema nullable — shorthand for `union(schema).or(nul())`. */
     nullable(): NullableReturn<
         AnySchemaBuilder<true, undefined, false, AnyBuiltinExtensions>
+    >;
+}
+
+/** Methods threaded through `TExtensions` for `TupleSchemaBuilder`. */
+export interface TupleBuiltinExtensions<
+    TElements extends readonly SchemaBuilder<
+        any,
+        any,
+        any
+    >[] = readonly SchemaBuilder<any, any, any>[]
+> {
+    /** Makes this schema nullable — shorthand for `union(schema).or(nul())`. */
+    nullable(): NullableReturn<
+        TupleSchemaBuilder<
+            TElements,
+            true,
+            undefined,
+            false,
+            TupleBuiltinExtensions<TElements>
+        >
     >;
 }
 
@@ -272,6 +293,17 @@ export const nullableExtension = defineExtension({
          * @returns a `UnionSchemaBuilder` that accepts any value or `null`
          */
         nullable(this: AnySchemaBuilder) {
+            const u = union(this).or(nul());
+            return this.isRequired ? u : u.optional();
+        }
+    },
+    tuple: {
+        /**
+         * Makes this schema nullable — shorthand for `union(schema).or(nul())`.
+         *
+         * @returns a `UnionSchemaBuilder` that accepts the tuple type or `null`
+         */
+        nullable(this: TupleSchemaBuilder<any>) {
             const u = union(this).or(nul());
             return this.isRequired ? u : u.optional();
         }

--- a/libs/schema/src/index.ts
+++ b/libs/schema/src/index.ts
@@ -1,6 +1,11 @@
 // Re-export all types, classes, and extension system from core
 
 export { LazySchemaBuilder, lazy } from './builders/LazySchemaBuilder.js';
+export type {
+    TupleElementValidationResults,
+    TupleSchemaValidationResult
+} from './builders/TupleSchemaBuilder.js';
+export { TupleSchemaBuilder } from './builders/TupleSchemaBuilder.js';
 export * from './core.js';
 // Override bare factory functions with augmented versions (extensions pre-applied).
 // Named re-exports shadow the identically-named exports from `export *` above.
@@ -23,6 +28,7 @@ export {
     type ExtendedNumber,
     type ExtendedObject,
     type ExtendedString,
+    type ExtendedTuple,
     type ExtendedUnion,
     type FuncBuiltinExtensions,
     func,
@@ -37,6 +43,8 @@ export {
     type StringBuiltinExtensions,
     string,
     stringExtensions,
+    type TupleBuiltinExtensions,
+    tuple,
     type UnionBuiltinExtensions,
     union
 } from './extensions/index.js';

--- a/libs/schema/tsup.config.ts
+++ b/libs/schema/tsup.config.ts
@@ -12,7 +12,8 @@ export default defineConfig({
         'src/builders/DateSchemaBuilder.ts',
         'src/builders/AnySchemaBuilder.ts',
         'src/builders/UnionSchemaBuilder.ts',
-        'src/builders/FunctionSchemaBuilder.ts'
+        'src/builders/FunctionSchemaBuilder.ts',
+        'src/builders/TupleSchemaBuilder.ts'
     ],
     format: ['esm'],
     tsconfig: './tsconfig.build.json',

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,6 +151,22 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@babel/code-frame": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.28.5",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-string-parser": {
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -831,6 +847,43 @@
             "license": "MIT",
             "engines": {
                 "node": ">=20.19.0"
+            }
+        },
+        "node_modules/@emnapi/core": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+            "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+            "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -2211,6 +2264,27 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@testing-library/dom": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+            "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/runtime": "^7.12.5",
+                "@types/aria-query": "^5.0.1",
+                "aria-query": "5.3.0",
+                "dom-accessibility-api": "^0.5.9",
+                "lz-string": "^1.5.0",
+                "picocolors": "1.1.1",
+                "pretty-format": "^27.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@testing-library/react": {
             "version": "16.3.2",
             "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
@@ -2333,6 +2407,14 @@
             "dependencies": {
                 "tslib": "^2.4.0"
             }
+        },
+        "node_modules/@types/aria-query": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+            "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/chai": {
             "version": "5.2.3",
@@ -2573,6 +2655,20 @@
                 "node": ">=8"
             }
         },
+        "node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
         "node_modules/any-promise": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -2586,6 +2682,17 @@
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true,
             "license": "Python-2.0"
+        },
+        "node_modules/aria-query": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+            "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "dequal": "^2.0.3"
+            }
         },
         "node_modules/array-union": {
             "version": "2.1.0",
@@ -2744,6 +2851,13 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/colorette": {
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+            "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/commander": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2853,6 +2967,17 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/dequal": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/detect-indent": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
@@ -2885,6 +3010,14 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/dom-accessibility-api": {
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+            "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/enquirer": {
             "version": "2.4.1",
@@ -2960,6 +3093,26 @@
                 "@esbuild/win32-arm64": "0.27.7",
                 "@esbuild/win32-ia32": "0.27.7",
                 "@esbuild/win32-x64": "0.27.7"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/esm": {
+            "version": "3.2.25",
+            "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+            "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/esprima": {
@@ -3099,6 +3252,33 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-package-type": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+            "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/getopts": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
+            "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA==",
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/glob-parent": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -3148,6 +3328,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/html-encoding-sniffer": {
@@ -3205,6 +3398,32 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
+            }
+        },
+        "node_modules/interpret": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+            "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-extglob": {
@@ -3339,6 +3558,14 @@
                 "node": ">=10"
             }
         },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/js-yaml": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -3402,6 +3629,99 @@
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
+        },
+        "node_modules/knex": {
+            "version": "3.2.8",
+            "resolved": "https://registry.npmjs.org/knex/-/knex-3.2.8.tgz",
+            "integrity": "sha512-ElXXxu9Nq+5hWYdBUddYIWIT5yKKs5KNCsmKGbJSHPyaMpAABp3xs4L55GgdQoAs6QQ7dv72ai3M4pxYQ8utEg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "colorette": "2.0.19",
+                "commander": "^10.0.0",
+                "debug": "4.3.4",
+                "escalade": "^3.1.1",
+                "esm": "^3.2.25",
+                "get-package-type": "^0.1.0",
+                "getopts": "2.3.0",
+                "interpret": "^2.2.0",
+                "lodash": "^4.17.21",
+                "pg-connection-string": "2.6.2",
+                "rechoir": "^0.8.0",
+                "resolve-from": "^5.0.0",
+                "tarn": "^3.0.2",
+                "tildify": "2.0.0"
+            },
+            "bin": {
+                "knex": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "pg-query-stream": "^4.14.0"
+            },
+            "peerDependenciesMeta": {
+                "better-sqlite3": {
+                    "optional": true
+                },
+                "mysql": {
+                    "optional": true
+                },
+                "mysql2": {
+                    "optional": true
+                },
+                "pg": {
+                    "optional": true
+                },
+                "pg-native": {
+                    "optional": true
+                },
+                "pg-query-stream": {
+                    "optional": true
+                },
+                "sqlite3": {
+                    "optional": true
+                },
+                "tedious": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/knex/node_modules/commander": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/knex/node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/knex/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lightningcss": {
             "version": "1.32.0",
@@ -3717,6 +4037,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/lodash": {
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/lodash.startcase": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
@@ -3740,6 +4067,17 @@
             "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/lz-string": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+            "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "lz-string": "bin/bin.js"
+            }
         },
         "node_modules/magic-string": {
             "version": "0.30.21",
@@ -4058,6 +4396,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/path-type": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -4074,6 +4419,13 @@
             "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/pg-connection-string": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
+            "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -4215,6 +4567,22 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/pretty-format": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^17.0.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
         "node_modules/property-expr": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
@@ -4289,6 +4657,28 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/react-dom": {
+            "version": "19.2.4",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+            "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "scheduler": "^0.27.0"
+            },
+            "peerDependencies": {
+                "react": "^19.2.4"
+            }
+        },
+        "node_modules/react-is": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/read-yaml-file": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
@@ -4343,6 +4733,19 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/rechoir": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+            "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "resolve": "^1.20.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            }
+        },
         "node_modules/require-from-string": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4353,11 +4756,31 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/resolve": {
+            "version": "1.22.11",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+            "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "is-core-module": "^2.16.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/resolve-from": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -4496,6 +4919,14 @@
             "engines": {
                 "node": ">=v12.22.7"
             }
+        },
+        "node_modules/scheduler": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+            "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/semver": {
             "version": "7.7.4",
@@ -4674,12 +5105,35 @@
                 "node": ">=8"
             }
         },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/tarn": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.2.tgz",
+            "integrity": "sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8.0.0"
+            }
         },
         "node_modules/term-size": {
             "version": "2.2.1",
@@ -4715,6 +5169,16 @@
             },
             "engines": {
                 "node": ">=0.8"
+            }
+        },
+        "node_modules/tildify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
+            "integrity": "sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/tiny-case": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,22 +151,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@babel/code-frame": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.28.5",
-                "js-tokens": "^4.0.0",
-                "picocolors": "^1.1.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/helper-string-parser": {
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -847,43 +831,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=20.19.0"
-            }
-        },
-        "node_modules/@emnapi/core": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-            "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/runtime": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-            "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -2264,27 +2211,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@testing-library/dom": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-            "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/runtime": "^7.12.5",
-                "@types/aria-query": "^5.0.1",
-                "aria-query": "5.3.0",
-                "dom-accessibility-api": "^0.5.9",
-                "lz-string": "^1.5.0",
-                "picocolors": "1.1.1",
-                "pretty-format": "^27.0.2"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/@testing-library/react": {
             "version": "16.3.2",
             "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
@@ -2407,14 +2333,6 @@
             "dependencies": {
                 "tslib": "^2.4.0"
             }
-        },
-        "node_modules/@types/aria-query": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-            "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/@types/chai": {
             "version": "5.2.3",
@@ -2655,20 +2573,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "node_modules/any-promise": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -2682,17 +2586,6 @@
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true,
             "license": "Python-2.0"
-        },
-        "node_modules/aria-query": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-            "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "peer": true,
-            "dependencies": {
-                "dequal": "^2.0.3"
-            }
         },
         "node_modules/array-union": {
             "version": "2.1.0",
@@ -2851,13 +2744,6 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
-        "node_modules/colorette": {
-            "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
-            "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/commander": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2967,17 +2853,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/dequal": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/detect-indent": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
@@ -3010,14 +2885,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/dom-accessibility-api": {
-            "version": "0.5.16",
-            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-            "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/enquirer": {
             "version": "2.4.1",
@@ -3093,26 +2960,6 @@
                 "@esbuild/win32-arm64": "0.27.7",
                 "@esbuild/win32-ia32": "0.27.7",
                 "@esbuild/win32-x64": "0.27.7"
-            }
-        },
-        "node_modules/escalade": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/esm": {
-            "version": "3.2.25",
-            "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-            "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/esprima": {
@@ -3252,33 +3099,6 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
-        "node_modules/function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "license": "MIT",
-            "peer": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-package-type": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-            "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/getopts": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
-            "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/glob-parent": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -3328,19 +3148,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/html-encoding-sniffer": {
@@ -3398,32 +3205,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
-            }
-        },
-        "node_modules/interpret": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-            "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/is-core-module": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-extglob": {
@@ -3558,14 +3339,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/js-tokens": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/js-yaml": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -3629,99 +3402,6 @@
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
-        },
-        "node_modules/knex": {
-            "version": "3.2.8",
-            "resolved": "https://registry.npmjs.org/knex/-/knex-3.2.8.tgz",
-            "integrity": "sha512-ElXXxu9Nq+5hWYdBUddYIWIT5yKKs5KNCsmKGbJSHPyaMpAABp3xs4L55GgdQoAs6QQ7dv72ai3M4pxYQ8utEg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "colorette": "2.0.19",
-                "commander": "^10.0.0",
-                "debug": "4.3.4",
-                "escalade": "^3.1.1",
-                "esm": "^3.2.25",
-                "get-package-type": "^0.1.0",
-                "getopts": "2.3.0",
-                "interpret": "^2.2.0",
-                "lodash": "^4.17.21",
-                "pg-connection-string": "2.6.2",
-                "rechoir": "^0.8.0",
-                "resolve-from": "^5.0.0",
-                "tarn": "^3.0.2",
-                "tildify": "2.0.0"
-            },
-            "bin": {
-                "knex": "bin/cli.js"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "peerDependencies": {
-                "pg-query-stream": "^4.14.0"
-            },
-            "peerDependenciesMeta": {
-                "better-sqlite3": {
-                    "optional": true
-                },
-                "mysql": {
-                    "optional": true
-                },
-                "mysql2": {
-                    "optional": true
-                },
-                "pg": {
-                    "optional": true
-                },
-                "pg-native": {
-                    "optional": true
-                },
-                "pg-query-stream": {
-                    "optional": true
-                },
-                "sqlite3": {
-                    "optional": true
-                },
-                "tedious": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/knex/node_modules/commander": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/knex/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/knex/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/lightningcss": {
             "version": "1.32.0",
@@ -4037,13 +3717,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/lodash": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/lodash.startcase": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
@@ -4067,17 +3740,6 @@
             "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/lz-string": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-            "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "bin": {
-                "lz-string": "bin/bin.js"
-            }
         },
         "node_modules/magic-string": {
             "version": "0.30.21",
@@ -4396,13 +4058,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/path-type": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -4419,13 +4074,6 @@
             "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/pg-connection-string": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
-            "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -4567,22 +4215,6 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
-        "node_modules/pretty-format": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^17.0.1"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
         "node_modules/property-expr": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
@@ -4657,28 +4289,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/react-dom": {
-            "version": "19.2.4",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-            "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "scheduler": "^0.27.0"
-            },
-            "peerDependencies": {
-                "react": "^19.2.4"
-            }
-        },
-        "node_modules/react-is": {
-            "version": "17.0.2",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/read-yaml-file": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
@@ -4733,19 +4343,6 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
-        "node_modules/rechoir": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
-            "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "resolve": "^1.20.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            }
-        },
         "node_modules/require-from-string": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4756,31 +4353,11 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/resolve": {
-            "version": "1.22.11",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-            "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "is-core-module": "^2.16.1",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/resolve-from": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -4919,14 +4496,6 @@
             "engines": {
                 "node": ">=v12.22.7"
             }
-        },
-        "node_modules/scheduler": {
-            "version": "0.27.0",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-            "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/semver": {
             "version": "7.7.4",
@@ -5105,35 +4674,12 @@
                 "node": ">=8"
             }
         },
-        "node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/tarn": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.2.tgz",
-            "integrity": "sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8.0.0"
-            }
         },
         "node_modules/term-size": {
             "version": "2.2.1",
@@ -5169,16 +4715,6 @@
             },
             "engines": {
                 "node": ">=0.8"
-            }
-        },
-        "node_modules/tildify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
-            "integrity": "sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/tiny-case": {

--- a/website/app/playground/examples/index.ts
+++ b/website/app/playground/examples/index.ts
@@ -30,7 +30,13 @@ export const EXAMPLE_GROUPS = [
     },
     {
         label: 'Arrays & Unions',
-        ids: ['arrays', 'union-types', 'discriminated-unions', 'nullable']
+        ids: [
+            'arrays',
+            'tuples',
+            'union-types',
+            'discriminated-unions',
+            'nullable'
+        ]
     },
     { label: 'Validation', ids: ['validation-errors', 'custom-validators'] },
     {
@@ -808,6 +814,38 @@ const result = User.validate({
 });
 `,
         testData: '{ "name": "Alice", "bio": null, "age": null }'
+    },
+    {
+        id: 'tuples',
+        title: 'Tuples',
+        description:
+            'Use <code>tuple([...schemas])</code> for fixed-length arrays with per-position types — mirrors TypeScript tuple types. Use <code>.rest(schema)</code> for variadic tails.',
+        group: 'Arrays & Unions',
+        code: `import { tuple, string, number, boolean } from '@cleverbrush/schema';
+
+// Fixed-length tuple: [string, number, boolean]
+const entry = tuple([string(), number(), boolean()]);
+
+// Validate a matching tuple
+const result = entry.validate(['hello', 42, true]);
+// result.valid === true, result.object === ['hello', 42, true]
+
+// Wrong type at position 1 → invalid
+const bad = entry.validate(['hello', 'oops', true] as any);
+// bad.valid === false
+
+// 2-D coordinate pair
+const point = tuple([number(), number()]);
+const p = point.validate([10.5, 20.3]);
+// p.object === [10.5, 20.3]
+
+// Variadic tail with .rest()
+const log = tuple([string(), number()]).rest(string());
+// Type: [string, number, ...string[]]
+const l = log.validate(['info', 200, 'request ok', 'extra detail']);
+// l.valid === true
+`,
+        testData: '["hello", 42, true]'
     },
     {
         id: 'custom-extensions',

--- a/website/app/playground/schemaDeclarations.ts
+++ b/website/app/playground/schemaDeclarations.ts
@@ -2728,6 +2728,234 @@ export declare function string<T extends string>(equals: T, errorMessage: Valida
 export declare function string(): StringSchemaBuilder<string, true>;
 export {};
 `,
+    "file:///node_modules/@cleverbrush/schema/builders/TupleSchemaBuilder.d.ts": `import type { ObjectSchemaBuilder, ObjectSchemaValidationResult } from './ObjectSchemaBuilder.js';
+import { type BRAND, type InferType, type NestedValidationResult, SchemaBuilder, type ValidationContext, type ValidationErrorMessageProvider, type ValidationResult } from './SchemaBuilder.js';
+import type { UnionSchemaBuilder, UnionSchemaValidationResult } from './UnionSchemaBuilder.js';
+/**
+ * Maps a tuple of schema builders to a tuple of their per-position
+ * validation result types.
+ * Union schema elements get \`UnionSchemaValidationResult\`,
+ * object schema elements get \`ObjectSchemaValidationResult\`,
+ * other types get \`ValidationResult\`.
+ */
+export type TupleElementValidationResults<TElements extends readonly SchemaBuilder<any, any, any>[]> = {
+    [K in keyof TElements]: TElements[K] extends UnionSchemaBuilder<infer UOptions extends readonly SchemaBuilder<any, any, any>[], any, any> ? UnionSchemaValidationResult<InferType<TElements[K]>, UOptions> : TElements[K] extends ObjectSchemaBuilder<any, any, any, any, any> ? ObjectSchemaValidationResult<InferType<TElements[K]>, TElements[K]> : ValidationResult<InferType<TElements[K]>>;
+};
+/**
+ * Validation result type returned by \`TupleSchemaBuilder.validate()\`.
+ * Extends \`ValidationResult\` with \`getNestedErrors\` for root-level tuple
+ * errors and per-position validation results.
+ */
+export type TupleSchemaValidationResult<TResult, TElements extends readonly SchemaBuilder<any, any, any>[]> = ValidationResult<TResult> & {
+    /**
+     * Returns root-level tuple validation errors combined with
+     * per-position validation results.
+     * The returned value has both \`NestedValidationResult\` properties
+     * (\`errors\`, \`isValid\`, \`descriptor\`, \`seenValue\`) and indexed
+     * position results (\`[0]\`, \`[1]\`, etc.).
+     */
+    getNestedErrors(): TupleElementValidationResults<TElements> & NestedValidationResult<any, any, any>;
+};
+type TupleSchemaBuilderCreateProps<TElements extends readonly SchemaBuilder<any, any, any>[], TRestSchema extends SchemaBuilder<any, any, any> | undefined = undefined, R extends boolean = true> = Partial<ReturnType<TupleSchemaBuilder<TElements, R, undefined, false, {}, TRestSchema>['introspect']>>;
+/**
+ * Fixed-length array schema builder with per-position type validation.
+ * Similar to TypeScript's tuple types — each element at a specific array index
+ * is validated against its own schema.
+ *
+ * Use it when you need to validate function arguments, CSV rows, coordinate
+ * pairs, structured event payloads, or any other fixed-structure array.
+ *
+ * **NOTE** this class is exported only to give opportunity to extend it
+ * by inheriting. It is not recommended to create an instance of this class
+ * directly. Use {@link tuple | tuple()} function instead.
+ *
+ * @example
+ * \`\`\`ts
+ * const schema = tuple([string(), number(), boolean()]);
+ * // Inferred TypeScript type: [string, number, boolean]
+ *
+ * schema.validate(['hello', 42, true]);
+ * // result.valid === true
+ * // result.object === ['hello', 42, true]
+ *
+ * schema.validate(['hello', 42]);
+ * // result.valid === false  (too few elements)
+ *
+ * schema.validate(['hello', 'oops', true]);
+ * // result.valid === false  (wrong type at position 1)
+ * \`\`\`
+ *
+ * @example
+ * \`\`\`ts
+ * // Tuple with variadic rest elements
+ * const schema = tuple([string(), number()]).rest(boolean());
+ * // Inferred TypeScript type: [string, number, ...boolean[]]
+ *
+ * schema.validate(['hello', 42, true, false]);
+ * // result.valid === true — any number of extra booleans allowed
+ * \`\`\`
+ *
+ * @example
+ * \`\`\`ts
+ * // Nested tuple combining with object schemas
+ * const point = tuple([number(), number()]);
+ * const segment = tuple([point, point]);
+ *
+ * segment.validate([[0, 0], [10, 20]]);
+ * // result.valid === true
+ * \`\`\`
+ *
+ * @see {@link tuple}
+ */
+export declare class TupleSchemaBuilder<TElements extends readonly SchemaBuilder<any, any, any>[], TRequired extends boolean = true, TExplicitType = undefined, THasDefault extends boolean = false, TExtensions = {}, TRestSchema extends SchemaBuilder<any, any, any> | undefined = undefined, TResult = TExplicitType extends undefined ? TRestSchema extends SchemaBuilder<any, any, any> ? [
+    ...{
+        [K in keyof TElements]: InferType<TElements[K]>;
+    },
+    ...Array<InferType<TRestSchema>>
+] : {
+    [K in keyof TElements]: InferType<TElements[K]>;
+} : TExplicitType> extends SchemaBuilder<TResult, TRequired, THasDefault, TExtensions> {
+    #private;
+    /**
+     * @hidden
+     */
+    static create(props: TupleSchemaBuilderCreateProps<any, any, any>): TupleSchemaBuilder<readonly SchemaBuilder<any, any, any, {}>[], true, undefined, false, {}, undefined, readonly any[]>;
+    protected constructor(props: TupleSchemaBuilderCreateProps<TElements, TRestSchema, TRequired>);
+    /**
+     * @inheritdoc
+     */
+    hasType<T>(_notUsed?: T): TupleSchemaBuilder<TElements, true, T, THasDefault, TExtensions, TRestSchema> & TExtensions;
+    /**
+     * @inheritdoc
+     */
+    clearHasType(): TupleSchemaBuilder<TElements, TRequired, undefined, THasDefault, TExtensions, TRestSchema> & TExtensions;
+    /**
+     * Performs synchronous validation of the schema over \`object\`.
+     * Throws if any preprocessor, validator, or error message provider returns a Promise.
+     * @param context Optional \`ValidationContext\` settings.
+     */
+    validate(object: TResult, context?: ValidationContext): TupleSchemaValidationResult<TResult, TElements>;
+    /**
+     * Performs async validation of the schema over \`object\`.
+     * Supports async preprocessors, validators, and error message providers.
+     * @param context Optional \`ValidationContext\` settings.
+     */
+    validateAsync(object: TResult, context?: ValidationContext): Promise<TupleSchemaValidationResult<TResult, TElements>>;
+    /**
+     * @hidden
+     */
+    protected createFromProps<TReq extends boolean>(props: TupleSchemaBuilderCreateProps<TElements, TRestSchema, TReq>): this;
+    /**
+     * @hidden
+     */
+    required(errorMessage?: ValidationErrorMessageProvider): TupleSchemaBuilder<TElements, true, TExplicitType, THasDefault, TExtensions, TRestSchema> & TExtensions;
+    /**
+     * @hidden
+     */
+    optional(): TupleSchemaBuilder<TElements, false, TExplicitType, THasDefault, TExtensions, TRestSchema> & TExtensions;
+    /**
+     * @hidden
+     */
+    default(value: TResult | (() => TResult)): TupleSchemaBuilder<TElements, true, TExplicitType, true, TExtensions, TRestSchema> & TExtensions;
+    /**
+     * @hidden
+     */
+    clearDefault(): TupleSchemaBuilder<TElements, TRequired, TExplicitType, false, TExtensions, TRestSchema> & TExtensions;
+    /**
+     * @hidden
+     */
+    brand<TBrand extends string | symbol>(_name?: TBrand): TupleSchemaBuilder<TElements, TRequired, TResult & {
+        readonly [K in BRAND]: TBrand;
+    }, THasDefault, TExtensions, TRestSchema> & TExtensions;
+    introspect(): {
+        /**
+         * Per-position element schemas defining the fixed tuple structure.
+         */
+        elements: TElements;
+        /**
+         * Optional schema for elements beyond the fixed positions.
+         * When set, additional elements are validated against this schema.
+         * Mirrors TypeScript's rest element syntax: \`[string, number, ...boolean[]]\`.
+         */
+        restSchema: (TRestSchema & SchemaBuilder<any, any, any, {}>) | undefined;
+        type: string;
+        isRequired: boolean;
+        preprocessors: readonly import("./SchemaBuilder.js").PreprocessorEntry<TResult>[];
+        validators: readonly import("./SchemaBuilder.js").ValidatorEntry<TResult>[];
+        requiredValidationErrorMessageProvider: ValidationErrorMessageProvider<SchemaBuilder<any, any, any, {}>>;
+        extensions: {
+            [x: string]: unknown;
+        };
+        hasDefault: boolean;
+        defaultValue: TResult | (() => TResult) | undefined;
+    };
+    /**
+     * Sets a schema that all elements beyond the fixed positions must satisfy.
+     * Mirrors TypeScript's variadic tuple tail: \`[string, number, ...boolean[]]\`.
+     *
+     * When set, the tuple length must be at least equal to the number of fixed
+     * elements, and any additional elements are validated against \`schema\`.
+     * When not set, the tuple length must be exactly equal to the fixed count.
+     *
+     * @param schema Schema that extra array elements must satisfy.
+     *
+     * @example
+     * \`\`\`ts
+     * const schema = tuple([string(), number()]).rest(boolean());
+     * // Inferred TypeScript type: [string, number, ...boolean[]]
+     *
+     * schema.validate(['hello', 42]);               // valid
+     * schema.validate(['hello', 42, true]);          // valid
+     * schema.validate(['hello', 42, true, false]);   // valid
+     * schema.validate(['hello', 42, 'extra']);       // invalid — 'extra' not boolean
+     * \`\`\`
+     */
+    rest<TSchema extends SchemaBuilder<any, any, any>>(schema: TSchema): TupleSchemaBuilder<TElements, TRequired, TExplicitType, THasDefault, TExtensions, TSchema> & TExtensions;
+    /**
+     * Removes the rest schema set by \`rest()\`. After this call, the tuple
+     * length must be exactly equal to the number of fixed element schemas.
+     */
+    clearRest(): TupleSchemaBuilder<TElements, TRequired, TExplicitType, THasDefault, TExtensions, undefined> & TExtensions;
+}
+/**
+ * Creates a fixed-length array schema (tuple) where each element at a
+ * specific index is validated against its own schema.
+ *
+ * @param elements Array of per-position schemas. The length of this array
+ *   determines the required tuple length (unless \`.rest()\` is used).
+ *
+ * @example
+ * \`\`\`ts
+ * import { tuple, string, number, boolean } from '@cleverbrush/schema';
+ *
+ * const schema = tuple([string(), number(), boolean()]);
+ * // Inferred TypeScript type: [string, number, boolean]
+ *
+ * schema.validate(['hello', 42, true]);     // valid
+ * schema.validate(['hello', 42]);           // invalid — too few elements
+ * schema.validate(['hello', 'oops', true]); // invalid — wrong type at [1]
+ * \`\`\`
+ *
+ * @example
+ * \`\`\`ts
+ * // 2-D coordinate pair
+ * const point = tuple([number(), number()]);
+ * const result = point.validate([10.5, 20.3]);
+ * // result.valid === true
+ * // result.object === [10.5, 20.3]
+ * \`\`\`
+ *
+ * @example
+ * \`\`\`ts
+ * // Optional tuple with default value
+ * const schema = tuple([string(), number()])
+ *     .optional()
+ *     .default(() => ['', 0]);
+ * \`\`\`
+ */
+export declare const tuple: <const TElements extends readonly SchemaBuilder<any, any, any>[]>(elements: [...TElements]) => TupleSchemaBuilder<TElements, true>;
+export {};
+`,
     "file:///node_modules/@cleverbrush/schema/builders/UnionSchemaBuilder.d.ts": `import type { ObjectSchemaBuilder, ObjectSchemaValidationResult } from './ObjectSchemaBuilder.js';
 import { type BRAND, type InferType, type NestedValidationResult, SchemaBuilder, type ValidationContext, type ValidationErrorMessageProvider, type ValidationResult } from './SchemaBuilder.js';
 type UnionSchemaBuilderCreateProps<T extends readonly SchemaBuilder<any, any, any>[], R extends boolean = true> = Partial<ReturnType<UnionSchemaBuilder<T, R>['introspect']>>;
@@ -2944,6 +3172,8 @@ export { ObjectSchemaBuilder, object, SchemaPropertySelector } from './builders/
 export type { PropertyDescriptor, PropertyDescriptorInner, PropertyDescriptorTree, PropertySetterOptions, ValidationErrorMessageProvider } from './builders/SchemaBuilder.js';
 export { BRAND, Brand, InferType, MakeOptional, SchemaBuilder, SchemaValidationError, SYMBOL_SCHEMA_PROPERTY_DESCRIPTOR, ValidationError, ValidationResult } from './builders/SchemaBuilder.js';
 export { StringSchemaBuilder, string } from './builders/StringSchemaBuilder.js';
+export type { TupleElementValidationResults, TupleSchemaValidationResult } from './builders/TupleSchemaBuilder.js';
+export { TupleSchemaBuilder, tuple } from './builders/TupleSchemaBuilder.js';
 export type { OptionValidationResults, UnionSchemaValidationResult } from './builders/UnionSchemaBuilder.js';
 export { UnionSchemaBuilder, union } from './builders/UnionSchemaBuilder.js';
 export type { CleanExtended, ExtensionConfig, ExtensionDescriptor, FixedMethods, HiddenExtensionMethods } from './extension.js';
@@ -3022,6 +3252,7 @@ import { NumberSchemaBuilder } from './builders/NumberSchemaBuilder.js';
 import { ObjectSchemaBuilder } from './builders/ObjectSchemaBuilder.js';
 import type { SchemaBuilder } from './builders/SchemaBuilder.js';
 import { StringSchemaBuilder } from './builders/StringSchemaBuilder.js';
+import { TupleSchemaBuilder } from './builders/TupleSchemaBuilder.js';
 import { UnionSchemaBuilder } from './builders/UnionSchemaBuilder.js';
 /**
  * Maps each builder type name to the corresponding generic builder class.
@@ -3038,6 +3269,7 @@ type BuilderMap = {
     date: DateSchemaBuilder<any, any, any, any>;
     object: ObjectSchemaBuilder<any, any, any, any, any>;
     array: ArraySchemaBuilder<any, any, any, any, any, any>;
+    tuple: TupleSchemaBuilder<any, any, any, any, any, any>;
     union: UnionSchemaBuilder<any, any, any, any, any>;
     func: FunctionSchemaBuilder<any, any, any, any, any>;
     any: AnySchemaBuilder<any, any, any, any, any>;
@@ -3165,6 +3397,7 @@ type ExtendedArrayFactory<TExt> = <TElementSchema extends SchemaBuilder<any, any
 type ExtendedUnionFactory<TExt> = <T extends SchemaBuilder<any, any, any>>(schema: T) => CleanExtended<UnionSchemaBuilder<[T], true, undefined, false, TExt>, TExt>;
 type ExtendedFuncFactory<TExt> = () => CleanExtended<FunctionSchemaBuilder<true, undefined, false, TExt>, TExt>;
 type ExtendedAnyFactory<TExt> = () => CleanExtended<AnySchemaBuilder<true, undefined, false, TExt>, TExt>;
+type ExtendedTupleFactory<TExt> = <const TElements extends readonly SchemaBuilder<any, any, any>[]>(elements: [...TElements]) => CleanExtended<TupleSchemaBuilder<TElements, true, undefined, false, TExt>, TExt>;
 /**
  * The return type of {@link withExtensions}.
  *
@@ -3184,6 +3417,7 @@ type WithExtensionsResult<TExts extends readonly ExtensionDescriptor<any>[]> = {
     date: ExtendedDateFactory<MergeExtensionMethods<TExts, 'date'>>;
     object: ExtendedObjectFactory<MergeExtensionMethods<TExts, 'object'>>;
     array: ExtendedArrayFactory<MergeExtensionMethods<TExts, 'array'>>;
+    tuple: ExtendedTupleFactory<MergeExtensionMethods<TExts, 'tuple'>>;
     union: ExtendedUnionFactory<MergeExtensionMethods<TExts, 'union'>>;
     func: ExtendedFuncFactory<MergeExtensionMethods<TExts, 'func'>>;
     any: ExtendedAnyFactory<MergeExtensionMethods<TExts, 'any'>>;
@@ -3493,14 +3727,15 @@ import type { NumberSchemaBuilder } from '../builders/NumberSchemaBuilder.js';
 import type { ObjectSchemaBuilder } from '../builders/ObjectSchemaBuilder.js';
 import type { SchemaBuilder } from '../builders/SchemaBuilder.js';
 import type { StringSchemaBuilder } from '../builders/StringSchemaBuilder.js';
+import type { TupleSchemaBuilder } from '../builders/TupleSchemaBuilder.js';
 import type { UnionSchemaBuilder } from '../builders/UnionSchemaBuilder.js';
 import type { HiddenExtensionMethods } from '../extension.js';
 import type { ArrayBuiltinExtensions } from './array.js';
-import type { AnyBuiltinExtensions, BooleanBuiltinExtensions, DateBuiltinExtensions, FuncBuiltinExtensions, ObjectBuiltinExtensions, UnionBuiltinExtensions } from './nullable.js';
+import type { AnyBuiltinExtensions, BooleanBuiltinExtensions, DateBuiltinExtensions, FuncBuiltinExtensions, ObjectBuiltinExtensions, TupleBuiltinExtensions, UnionBuiltinExtensions } from './nullable.js';
 import type { NumberBuiltinExtensions } from './number.js';
 import type { StringBuiltinExtensions } from './string.js';
 export { type ArrayBuiltinExtensions, arrayExtensions } from './array.js';
-export { type AnyBuiltinExtensions, type BooleanBuiltinExtensions, type DateBuiltinExtensions, type FuncBuiltinExtensions, type NullableMethod, type NullableReturn, nullableExtension, type ObjectBuiltinExtensions, type UnionBuiltinExtensions } from './nullable.js';
+export { type AnyBuiltinExtensions, type BooleanBuiltinExtensions, type DateBuiltinExtensions, type FuncBuiltinExtensions, type NullableMethod, type NullableReturn, nullableExtension, type ObjectBuiltinExtensions, type TupleBuiltinExtensions, type UnionBuiltinExtensions } from './nullable.js';
 export { type NumberBuiltinExtensions, numberExtensions } from './number.js';
 export { type StringBuiltinExtensions, stringExtensions } from './string.js';
 /** A \`StringSchemaBuilder\` with built-in extension methods. */
@@ -3521,6 +3756,8 @@ export type ExtendedUnion<TOptions extends readonly SchemaBuilder<any, any, any>
 export type ExtendedFunc = FunctionSchemaBuilder<true, undefined, false, FuncBuiltinExtensions> & FuncBuiltinExtensions & HiddenExtensionMethods;
 /** An \`AnySchemaBuilder\` with built-in extension methods. */
 export type ExtendedAny = AnySchemaBuilder<true, undefined, false, AnyBuiltinExtensions> & AnyBuiltinExtensions & HiddenExtensionMethods;
+/** A \`TupleSchemaBuilder\` with built-in extension methods. */
+export type ExtendedTuple<TElements extends readonly SchemaBuilder<any, any, any>[] = readonly SchemaBuilder<any, any, any>[]> = TupleSchemaBuilder<TElements, true, undefined, false, TupleBuiltinExtensions<TElements>> & TupleBuiltinExtensions<TElements> & HiddenExtensionMethods;
 export declare const string: {
     (): ExtendedString;
     <T extends string>(equals: T): ExtendedString<T>;
@@ -3540,6 +3777,7 @@ export declare const object: {
 export declare const union: <TOptions extends SchemaBuilder<any, any, any>>(schema: TOptions) => ExtendedUnion<[TOptions]>;
 export declare const func: () => ExtendedFunc;
 export declare const any: () => ExtendedAny;
+export declare const tuple: <const TElements extends readonly SchemaBuilder<any, any, any>[]>(elements: [...TElements]) => ExtendedTuple<TElements>;
 `,
     "file:///node_modules/@cleverbrush/schema/extensions/nullable.d.ts": `/**
  * Built-in nullable extension for \`@cleverbrush/schema\`.
@@ -3563,6 +3801,7 @@ import type { NumberSchemaBuilder } from '../builders/NumberSchemaBuilder.js';
 import type { ObjectSchemaBuilder } from '../builders/ObjectSchemaBuilder.js';
 import type { SchemaBuilder } from '../builders/SchemaBuilder.js';
 import type { StringSchemaBuilder } from '../builders/StringSchemaBuilder.js';
+import type { TupleSchemaBuilder } from '../builders/TupleSchemaBuilder.js';
 import { type UnionSchemaBuilder } from '../builders/UnionSchemaBuilder.js';
 /**
  * The return type produced by \`.nullable()\` on any schema builder \`TBuilder\`.
@@ -3612,6 +3851,11 @@ export interface FuncBuiltinExtensions {
 export interface AnyBuiltinExtensions {
     /** Makes this schema nullable — shorthand for \`union(schema).or(nul())\`. */
     nullable(): NullableReturn<AnySchemaBuilder<true, undefined, false, AnyBuiltinExtensions>>;
+}
+/** Methods threaded through \`TExtensions\` for \`TupleSchemaBuilder\`. */
+export interface TupleBuiltinExtensions<TElements extends readonly SchemaBuilder<any, any, any>[] = readonly SchemaBuilder<any, any, any>[]> {
+    /** Makes this schema nullable — shorthand for \`union(schema).or(nul())\`. */
+    nullable(): NullableReturn<TupleSchemaBuilder<TElements, true, undefined, false, TupleBuiltinExtensions<TElements>>>;
 }
 export interface NullableMethod<TBuilder extends SchemaBuilder<any, any, any>> {
     /**
@@ -3741,6 +3985,14 @@ export declare const nullableExtension: import("../extension.js").ExtensionDescr
          * @returns a \`UnionSchemaBuilder\` that accepts any value or \`null\`
          */
         nullable(this: AnySchemaBuilder): UnionSchemaBuilder<[AnySchemaBuilder<true, undefined, false, {}, any>, NullSchemaBuilder<true, undefined, false, {}>], true, undefined, false, {}> | UnionSchemaBuilder<[AnySchemaBuilder<true, undefined, false, {}, any>, NullSchemaBuilder<true, undefined, false, {}>], false, undefined, false, {}>;
+    };
+    tuple: {
+        /**
+         * Makes this schema nullable — shorthand for \`union(schema).or(nul())\`.
+         *
+         * @returns a \`UnionSchemaBuilder\` that accepts the tuple type or \`null\`
+         */
+        nullable(this: TupleSchemaBuilder<any>): UnionSchemaBuilder<[TupleSchemaBuilder<any, true, undefined, false, {}, undefined, any[]>, NullSchemaBuilder<true, undefined, false, {}>], true, undefined, false, {}> | UnionSchemaBuilder<[TupleSchemaBuilder<any, true, undefined, false, {}, undefined, any[]>, NullSchemaBuilder<true, undefined, false, {}>], false, undefined, false, {}>;
     };
 }>;
 `,
@@ -4225,8 +4477,10 @@ export declare function resolveErrorMessageAsync(provider: ValidationErrorMessag
 export {};
 `,
     "file:///node_modules/@cleverbrush/schema/index.d.ts": `export { LazySchemaBuilder, lazy } from './builders/LazySchemaBuilder.js';
+export type { TupleElementValidationResults, TupleSchemaValidationResult } from './builders/TupleSchemaBuilder.js';
+export { TupleSchemaBuilder } from './builders/TupleSchemaBuilder.js';
 export * from './core.js';
-export { type AnyBuiltinExtensions, type ArrayBuiltinExtensions, any, array, arrayExtensions, type BooleanBuiltinExtensions, boolean, type DateBuiltinExtensions, date, type ExtendedAny, type ExtendedArray, type ExtendedBoolean, type ExtendedDate, type ExtendedFunc, type ExtendedNumber, type ExtendedObject, type ExtendedString, type ExtendedUnion, type FuncBuiltinExtensions, func, type NullableMethod, type NullableReturn, type NumberBuiltinExtensions, nullableExtension, number, numberExtensions, type ObjectBuiltinExtensions, object, type StringBuiltinExtensions, string, stringExtensions, type UnionBuiltinExtensions, union } from './extensions/index.js';
+export { type AnyBuiltinExtensions, type ArrayBuiltinExtensions, any, array, arrayExtensions, type BooleanBuiltinExtensions, boolean, type DateBuiltinExtensions, date, type ExtendedAny, type ExtendedArray, type ExtendedBoolean, type ExtendedDate, type ExtendedFunc, type ExtendedNumber, type ExtendedObject, type ExtendedString, type ExtendedTuple, type ExtendedUnion, type FuncBuiltinExtensions, func, type NullableMethod, type NullableReturn, type NumberBuiltinExtensions, nullableExtension, number, numberExtensions, type ObjectBuiltinExtensions, object, type StringBuiltinExtensions, string, stringExtensions, type TupleBuiltinExtensions, tuple, type UnionBuiltinExtensions, union } from './extensions/index.js';
 `,
     "file:///node_modules/@cleverbrush/schema/utils/transaction.d.ts": `/**
  * Options for customizing transaction behavior.

--- a/website/app/playground/useTypeInference.ts
+++ b/website/app/playground/useTypeInference.ts
@@ -100,7 +100,7 @@ async function doExtractFast(
 
         const schemaVarMatch = [
             ...code.matchAll(
-                /(?:const|let)\s+(\w+)\s*=\s*(?:string|number|boolean|date|func|any|object|array|union)/g
+                /(?:const|let)\s+(\w+)\s*=\s*(?:string|number|boolean|date|func|any|object|array|union|tuple)/g
             )
         ];
         const resultVarMatch = [
@@ -329,7 +329,11 @@ type DocTree = Map<string, DocNode>;
 const INFER_MARKER = '__PlaygroundInferred';
 const RESULT_OBJ_MARKER = '__PlaygroundResultObj';
 /** Deep-expand helper injected into temp models to force TS to eagerly resolve mapped/generic types */
-const RESOLVE_HELPER = `\ntype __Resolve<T> = T extends Date ? Date : T extends RegExp ? RegExp : T extends Map<infer K, infer V> ? Map<K, V> : T extends Set<infer V> ? Set<V> : T extends Promise<infer V> ? Promise<V> : T extends Error ? Error : T extends readonly (infer E)[] ? __Resolve<E>[] : T extends object ? { [K in keyof T]: __Resolve<T[K]> } : T;\n`;
+// Tuple-safe resolve helper:
+// Fixed-length tuples: number extends T["length"] is false → return T unchanged.
+// Non-empty variadic tuples ([A, B, ...C[]]): length is number, but T extends readonly [unknown, ...unknown[]] → return T unchanged.
+// Plain arrays (string[], Obj[]): length is number, no guaranteed first element → resolve element type.
+const RESOLVE_HELPER = `\ntype __Resolve<T> = T extends Date ? Date : T extends RegExp ? RegExp : T extends Map<infer K, infer V> ? Map<K, V> : T extends Set<infer V> ? Set<V> : T extends Promise<infer V> ? Promise<V> : T extends Error ? Error : T extends readonly unknown[] ? (number extends T["length"] ? (T extends readonly [unknown, ...unknown[]] ? T : __Resolve<T[number]>[]) : T) : T extends object ? { [K in keyof T]: __Resolve<T[K]> } : T;\n`;
 let helperCounter = 0;
 const MAX_DOC_DEPTH = 4;
 

--- a/website/app/schema/page.tsx
+++ b/website/app/schema/page.tsx
@@ -352,6 +352,22 @@ console.log(bad.errors);
                                 </tr>
                                 <tr>
                                     <td>
+                                        <code>tuple([...schemas])</code>
+                                    </td>
+                                    <td>
+                                        Fixed-length array with per-position
+                                        types. Each index is validated against
+                                        its own schema — mirrors TypeScript
+                                        tuple types.
+                                    </td>
+                                    <td>
+                                        <code>.rest(schema)</code>,{' '}
+                                        <code>.optional()</code>,{' '}
+                                        <code>.default(value)</code>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
                                         <code>union(...schemas)</code>
                                     </td>
                                     <td>

--- a/website/app/schema/page.tsx
+++ b/website/app/schema/page.tsx
@@ -363,6 +363,7 @@ console.log(bad.errors);
                                     <td>
                                         <code>.rest(schema)</code>,{' '}
                                         <code>.optional()</code>,{' '}
+                                        <code>.nullable()</code>,{' '}
                                         <code>.default(value)</code>
                                     </td>
                                 </tr>


### PR DESCRIPTION
…n types

- Introduced TupleSchemaBuilder to validate fixed-length arrays, mirroring TypeScript tuple types.
- Added nullable extension for TupleSchemaBuilder to allow null values.
- Implemented tests for tuple validation, including acceptance of valid tuples and rejection of invalid ones.
- Updated playground examples and schema declarations to include tuple functionality.
- Enhanced type inference to support tuple types in the playground.