### PR TITLE
Add @cleverbrush/env library for type-safe environment variable parsing

### DIFF
--- a/.changeset/add-env-library.md
+++ b/.changeset/add-env-library.md
@@ -1,0 +1,18 @@
+---
+'@cleverbrush/env': minor
+---
+
+# @cleverbrush/env — Type-safe environment variables
+
+New library for parsing `process.env` into validated, typed, optionally nested config objects using `@cleverbrush/schema`.
+
+### Key features
+
+- **`env(varName, schema)`** — branded wrapper that binds a schema builder to an env var name
+- **`parseEnv(config, source?)`** — walks a nested config descriptor tree, reads env vars, validates and coerces via schema
+- **`parseEnvFlat(schemas, source?)`** — flat convenience mode where keys = env var names
+- **`splitBy(separator)`** — preprocessor helper for parsing comma-separated (or other delimited) env vars into arrays
+- **Computed values** — optional second argument to `parseEnv()` receives the fully typed base config and returns derived values, deep-merged into the result via `@cleverbrush/deep`
+- **Compile-time enforcement** — TypeScript errors if any config leaf is not wrapped with `env()`
+- **`EnvValidationError`** — lists all missing and invalid variables at once with config paths and types
+- **Full `@cleverbrush/schema` power** — `.coerce()`, `.default()`, `.minLength()`, custom validators all work

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,7 +11,8 @@
             "@cleverbrush/scheduler",
             "@cleverbrush/mapper",
             "@cleverbrush/knex-clickhouse",
-            "@cleverbrush/react-form"
+            "@cleverbrush/react-form",
+            "@cleverbrush/env"
         ]
     ],
     "linked": [],

--- a/libs/env/README.md
+++ b/libs/env/README.md
@@ -38,7 +38,7 @@ Type-safe environment variable parsing with `@cleverbrush/schema` — validated,
 npm install @cleverbrush/env
 ```
 
-**Peer dependency:** `@cleverbrush/schema`
+`@cleverbrush/env` uses `@cleverbrush/schema` internally; no separate peer dependency install is required.
 
 ## Quick Start
 

--- a/libs/env/README.md
+++ b/libs/env/README.md
@@ -1,0 +1,199 @@
+# @cleverbrush/env
+
+[![CI](https://github.com/cleverbrush/framework/actions/workflows/ci.yml/badge.svg)](https://github.com/cleverbrush/framework/actions/workflows/ci.yml)
+[![License: BSD-3-Clause](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](../../LICENSE)
+
+Type-safe environment variable parsing with `@cleverbrush/schema` — validated, coerced, structured configs from `process.env`.
+
+## Why @cleverbrush/env?
+
+**The problem:** Environment variables are untyped strings. Most apps access them via `process.env.SOME_VAR!` — no validation, no coercion, no structure. Missing variables surface as runtime crashes. Secrets accidentally leak into frontend bundles. Config objects are ad-hoc and fragile.
+
+**The solution:** `@cleverbrush/env` uses `@cleverbrush/schema` builders for validation and coercion, and a branded `env()` wrapper for type-safe variable binding. TypeScript enforces at **compile time** that every config leaf is bound to an environment variable. At runtime, all variables are validated at once and coerced to the correct types — with clear error messages for CI and startup logs.
+
+**What makes it different:**
+
+- **Compile-time enforcement** — forgetting `env()` on a config leaf is a TypeScript error, not a runtime surprise
+- **Structured configs** — nest objects arbitrarily deep; env vars map to leaf fields
+- **Validation & coercion** — full `@cleverbrush/schema` power: `.minLength()`, `.coerce()`, `.default()`, custom validators
+- **Array support** — `splitBy(',')` preprocessor for comma-separated values
+- **Clear error reporting** — lists all missing and invalid vars at once with paths and types
+- **Computed values** — derive values from resolved config via a type-safe callback
+- **Flat mode** — `parseEnvFlat()` for simple apps where keys = env var names
+
+| Feature | @cleverbrush/env | t3-env | envalid |
+| --- | --- | --- | --- |
+| Compile-time leaf enforcement | ✓ | ✗ | ✗ |
+| Nested config structures | ✓ | ✗ | ✗ |
+| Schema-based validation | ✓ | ✓ | ~ |
+| Type coercion (number, boolean, date) | ✓ | Manual | ✓ |
+| Array support | ✓ | ✗ | ✗ |
+| Computed / derived values | ✓ | ✗ | ✗ |
+| All-at-once error reporting | ✓ | ✓ | ✓ |
+| No Zod dependency | ✓ | ✗ | ✓ |
+
+## Installation
+
+```bash
+npm install @cleverbrush/env
+```
+
+**Peer dependency:** `@cleverbrush/schema`
+
+## Quick Start
+
+### Structured config (nested)
+
+```typescript
+import { env, parseEnv, splitBy } from '@cleverbrush/env';
+import { string, number, boolean, array } from '@cleverbrush/schema';
+
+const config = parseEnv({
+  db: {
+    host: env('DB_HOST', string().default('localhost')),
+    port: env('DB_PORT', number().coerce().default(5432)),
+    name: env('DB_NAME', string()),
+  },
+  jwt: {
+    secret: env('JWT_SECRET', string().minLength(32)),
+  },
+  debug: env('DEBUG', boolean().coerce().default(false)),
+  allowedOrigins: env(
+    'ALLOWED_ORIGINS',
+    array(string()).addPreprocessor(splitBy(','), { mutates: false })
+  ),
+});
+
+// Type is fully inferred:
+// {
+//   db: { host: string, port: number, name: string },
+//   jwt: { secret: string },
+//   debug: boolean,
+//   allowedOrigins: string[]
+// }
+```
+
+### Flat config
+
+For simple apps where each key is both the property name and the env var name:
+
+```typescript
+import { parseEnvFlat } from '@cleverbrush/env';
+import { string, number } from '@cleverbrush/schema';
+
+const config = parseEnvFlat({
+  DB_HOST: string().default('localhost'),
+  DB_PORT: number().coerce().default(5432),
+  JWT_SECRET: string().minLength(32),
+});
+// Type: { DB_HOST: string, DB_PORT: number, JWT_SECRET: string }
+```
+
+### Type enforcement
+
+Forgetting `env()` is a compile-time error:
+
+```typescript
+parseEnv({
+  db: {
+    host: string(),  // ← TypeScript ERROR: not assignable to EnvConfigNode
+  },
+});
+```
+
+### Array support
+
+Use the `splitBy()` preprocessor helper:
+
+```typescript
+// Comma-separated strings
+env('ALLOWED_ORIGINS', array(string()).addPreprocessor(splitBy(','), { mutates: false }))
+// "a, b, c" → ['a', 'b', 'c']
+
+// Comma-separated numbers
+env('PORTS', array(number().coerce()).addPreprocessor(splitBy(','), { mutates: false }))
+// "3000, 4000" → [3000, 4000]
+```
+
+### Error reporting
+
+When variables are missing or invalid, `EnvValidationError` is thrown with a formatted message:
+
+```
+Missing environment variables:
+  - DB_NAME (required by db.name) [string]
+  - JWT_SECRET (required by jwt.secret) [string]
+Invalid environment variables:
+  - DB_PORT: "abc" (required by db.port) — number expected
+```
+
+The error also exposes structured `.missing` and `.invalid` properties for programmatic access.
+
+### Custom source
+
+By default, `parseEnv()` reads from `process.env`. Pass a custom source for testing or alternative runtimes:
+
+```typescript
+const config = parseEnv(schema, {
+  DB_HOST: 'test-host',
+  DB_PORT: '9999',
+});
+```
+
+### Computed values
+
+Derive values from the resolved config by passing a compute callback as the second argument. The callback receives the fully typed base config and returns an object that is deep-merged into the result:
+
+```typescript
+import { env, parseEnv } from '@cleverbrush/env';
+import { string, number } from '@cleverbrush/schema';
+
+const config = parseEnv(
+  {
+    db: {
+      host: env('DB_HOST', string().default('localhost')),
+      port: env('DB_PORT', number().coerce().default(5432)),
+      name: env('DB_NAME', string()),
+    },
+  },
+  (base) => ({
+    db: {
+      connectionString: `postgres://${base.db.host}:${base.db.port}/${base.db.name}`,
+    },
+  })
+);
+
+// base is fully typed: { db: { host: string, port: number, name: string } }
+// Result type is deep-merged:
+// { db: { host: string, port: number, name: string, connectionString: string } }
+
+config.db.connectionString // "postgres://localhost:5432/mydb"
+```
+
+When using a compute callback, the optional source is passed as the third argument:
+
+```typescript
+const config = parseEnv(
+  { host: env('HOST', string()) },
+  (base) => ({ url: `http://${base.host}` }),
+  { HOST: 'example.com' }  // custom source
+);
+```
+
+## API Reference
+
+| Export | Type | Description |
+| --- | --- | --- |
+| `env(varName, schema)` | Function | Binds a schema to an env var name. Required for every leaf in `parseEnv()`. |
+| `parseEnv(config, source?)` | Function | Parses env vars into a validated, typed nested config object. |
+| `parseEnv(config, compute, source?)` | Function | Parses env vars, then deep-merges computed values from the callback. |
+| `parseEnvFlat(schemas, source?)` | Function | Flat convenience — keys are env var names, no `env()` needed. |
+| `splitBy(separator)` | Function | Preprocessor that splits a string into an array. |
+| `EnvValidationError` | Class | Thrown when env vars are missing or invalid. Has `.missing` and `.invalid`. |
+| `EnvField<T>` | Type | Branded wrapper type created by `env()`. |
+| `EnvConfig` | Type | Config descriptor tree type (input to `parseEnv`). |
+| `InferEnvConfig<T>` | Type | Infers the runtime type from a config descriptor. |
+
+## License
+
+[BSD-3-Clause](../../LICENSE)

--- a/libs/env/README.md
+++ b/libs/env/README.md
@@ -35,10 +35,10 @@ Type-safe environment variable parsing with `@cleverbrush/schema` — validated,
 ## Installation
 
 ```bash
-npm install @cleverbrush/env
+npm install @cleverbrush/env @cleverbrush/schema
 ```
 
-`@cleverbrush/env` uses `@cleverbrush/schema` internally; no separate peer dependency install is required.
+**Peer dependency:** `@cleverbrush/schema` must be installed separately.
 
 ## Quick Start
 

--- a/libs/env/package.json
+++ b/libs/env/package.json
@@ -1,0 +1,52 @@
+{
+    "author": "Andrew Zolotukhin <andrew_zol@cleverbrush.com>",
+    "bugs": {
+        "url": "https://github.com/cleverbrush/framework/issues",
+        "email": "andrew_zol@cleverbrush.com"
+    },
+    "dependencies": {
+        "@cleverbrush/deep": "^2.0.0",
+        "@cleverbrush/schema": "^2.0.0"
+    },
+    "description": "Type-safe environment variable parsing with @cleverbrush/schema — validated, coerced, structured configs from process.env",
+    "files": [
+        "dist"
+    ],
+    "homepage": "https://docs.cleverbrush.com/env",
+    "keywords": [
+        "environment variables",
+        "env",
+        "dotenv",
+        "config",
+        "type-safe",
+        "validation",
+        "typescript",
+        "cleverbrush"
+    ],
+    "license": "BSD 3-Clause",
+    "main": "./dist/index.js",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js"
+        }
+    },
+    "sideEffects": false,
+    "name": "@cleverbrush/env",
+    "readme": "https://github.com/cleverbrush/framework/tree/master/libs/env#readme",
+    "repository": {
+        "type": "git",
+        "url": "github:cleverbrush/framework"
+    },
+    "scripts": {
+        "watch": "tsc --build tsconfig.build.json --watch",
+        "build": "tsup && tsc --project tsconfig.build.json --emitDeclarationOnly",
+        "clean": "rm -rf dist tsconfig.build.tsbuildinfo"
+    },
+    "type": "module",
+    "devDependencies": {
+        "@types/node": "^25.4.0"
+    },
+    "types": "./dist/index.d.ts",
+    "version": "2.0.0"
+}

--- a/libs/env/package.json
+++ b/libs/env/package.json
@@ -5,7 +5,9 @@
         "email": "andrew_zol@cleverbrush.com"
     },
     "dependencies": {
-        "@cleverbrush/deep": "^2.0.0",
+        "@cleverbrush/deep": "^2.0.0"
+    },
+    "peerDependencies": {
         "@cleverbrush/schema": "^2.0.0"
     },
     "description": "Type-safe environment variable parsing with @cleverbrush/schema — validated, coerced, structured configs from process.env",

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -1,0 +1,33 @@
+import type { SchemaBuilder } from '@cleverbrush/schema';
+import { ENV_FIELD_BRAND, type EnvField } from './types.js';
+
+/**
+ * Associates a schema builder with an environment variable name.
+ *
+ * Every leaf field in a config descriptor passed to `parseEnv()` must be
+ * wrapped with `env()`. This is enforced at the TypeScript level — passing
+ * a bare schema builder produces a compile-time error.
+ *
+ * @param varName - The environment variable name to read (e.g. `'DB_HOST'`).
+ * @param schema  - A `@cleverbrush/schema` builder describing the expected
+ *                  type, constraints, coercion, and defaults.
+ * @returns A branded `EnvField` descriptor.
+ *
+ * @example
+ * ```ts
+ * env('DB_PORT', number().coerce().default(5432))
+ * ```
+ */
+export function env<T extends SchemaBuilder<any, any, any, any, any>>(
+    varName: string,
+    schema: T
+): EnvField<T> {
+    if (typeof varName !== 'string' || !varName) {
+        throw new Error('env(): varName must be a non-empty string');
+    }
+    return {
+        [ENV_FIELD_BRAND]: true,
+        varName,
+        schema
+    } as EnvField<T>;
+}

--- a/libs/env/src/errors.ts
+++ b/libs/env/src/errors.ts
@@ -1,0 +1,65 @@
+/**
+ * Describes a single missing environment variable.
+ */
+export interface MissingEnvVar {
+    /** The environment variable name (e.g. `'DB_HOST'`). */
+    varName: string;
+    /** Dot-separated config path (e.g. `'db.host'`). */
+    configPath: string;
+    /** Schema type identifier (e.g. `'string'`, `'number'`). */
+    type: string;
+}
+
+/**
+ * Describes a single invalid environment variable.
+ */
+export interface InvalidEnvVar {
+    /** The environment variable name (e.g. `'DB_PORT'`). */
+    varName: string;
+    /** Dot-separated config path (e.g. `'db.port'`). */
+    configPath: string;
+    /** The raw string value that failed validation. */
+    value: string;
+    /** Validation error messages. */
+    errors: string[];
+}
+
+/**
+ * Thrown by `parseEnv()` when one or more environment variables are missing
+ * or fail validation.
+ *
+ * The structured `missing` and `invalid` properties allow programmatic
+ * inspection, while the formatted `message` provides a human-readable
+ * summary suitable for CI logs and startup output.
+ */
+export class EnvValidationError extends Error {
+    public readonly missing: readonly MissingEnvVar[];
+    public readonly invalid: readonly InvalidEnvVar[];
+
+    constructor(missing: MissingEnvVar[], invalid: InvalidEnvVar[]) {
+        const lines: string[] = [];
+
+        if (missing.length > 0) {
+            lines.push('Missing environment variables:');
+            for (const m of missing) {
+                lines.push(
+                    `  - ${m.varName} (required by ${m.configPath}) [${m.type}]`
+                );
+            }
+        }
+
+        if (invalid.length > 0) {
+            lines.push('Invalid environment variables:');
+            for (const inv of invalid) {
+                lines.push(
+                    `  - ${inv.varName}: ${JSON.stringify(inv.value)} (required by ${inv.configPath}) — ${inv.errors.join('; ')}`
+                );
+            }
+        }
+
+        super(lines.join('\n'));
+        this.name = 'EnvValidationError';
+        this.missing = missing;
+        this.invalid = invalid;
+    }
+}

--- a/libs/env/src/index.ts
+++ b/libs/env/src/index.ts
@@ -1,0 +1,15 @@
+// Core API
+export { env } from './env.js';
+export type { InvalidEnvVar, MissingEnvVar } from './errors.js';
+// Error class
+export { EnvValidationError } from './errors.js';
+export { parseEnv } from './parseEnv.js';
+export { parseEnvFlat } from './parseEnvFlat.js';
+export { splitBy } from './splitBy.js';
+// Types
+export type {
+    EnvConfig,
+    EnvConfigNode,
+    EnvField,
+    InferEnvConfig
+} from './types.js';

--- a/libs/env/src/parseEnv.ts
+++ b/libs/env/src/parseEnv.ts
@@ -57,7 +57,7 @@ function walkConfig(
 
         if (isEnvField(node)) {
             const raw = source[node.varName];
-            rawObject[key] = raw;
+            rawObject[key] = raw === '' ? undefined : raw;
             mappings.push({
                 varName: node.varName,
                 configPath,

--- a/libs/env/src/parseEnv.ts
+++ b/libs/env/src/parseEnv.ts
@@ -1,0 +1,229 @@
+import { deepExtend, type Merge } from '@cleverbrush/deep';
+import { object, type SchemaBuilder } from '@cleverbrush/schema';
+import {
+    EnvValidationError,
+    type InvalidEnvVar,
+    type MissingEnvVar
+} from './errors.js';
+import {
+    ENV_FIELD_BRAND,
+    type EnvConfig,
+    type EnvField,
+    type InferEnvConfig
+} from './types.js';
+
+/**
+ * Returns `true` if the value is an `EnvField` (created by `env()`).
+ */
+function isEnvField(value: unknown): value is EnvField<any> {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        ENV_FIELD_BRAND in value &&
+        (value as any)[ENV_FIELD_BRAND] === true
+    );
+}
+
+/**
+ * Metadata collected during the config tree walk, tracking which env var
+ * maps to which config path for error reporting.
+ */
+interface EnvMapping {
+    varName: string;
+    configPath: string;
+    schema: SchemaBuilder<any, any, any, any, any>;
+}
+
+/**
+ * Recursively walks the config descriptor tree:
+ * - For `EnvField` leaves: reads `source[varName]` and places the raw value
+ * - For object branches: recurses into children
+ *
+ * @returns `rawObject` — a nested object with raw string values at the
+ *   correct paths, and `mappings` — an array tracking varName→configPath
+ *   for error reporting.
+ */
+function walkConfig(
+    config: Record<string, unknown>,
+    source: Record<string, string | undefined>,
+    pathPrefix: string
+): { rawObject: Record<string, unknown>; mappings: EnvMapping[] } {
+    const rawObject: Record<string, unknown> = {};
+    const mappings: EnvMapping[] = [];
+
+    for (const key of Object.keys(config)) {
+        const node = config[key];
+        const configPath = pathPrefix ? `${pathPrefix}.${key}` : key;
+
+        if (isEnvField(node)) {
+            const raw = source[node.varName];
+            rawObject[key] = raw;
+            mappings.push({
+                varName: node.varName,
+                configPath,
+                schema: node.schema
+            });
+        } else if (typeof node === 'object' && node !== null) {
+            const child = walkConfig(
+                node as Record<string, unknown>,
+                source,
+                configPath
+            );
+            rawObject[key] = child.rawObject;
+            mappings.push(...child.mappings);
+        }
+    }
+
+    return { rawObject, mappings };
+}
+
+/**
+ * Recursively builds an `ObjectSchemaBuilder` from the config descriptor tree.
+ *
+ * For `EnvField` leaves the inner schema is used directly.
+ * For object branches a nested `object()` schema is constructed.
+ */
+function buildSchema(
+    config: Record<string, unknown>
+): SchemaBuilder<any, any, any, any, any> {
+    const props: Record<string, SchemaBuilder<any, any, any, any, any>> = {};
+
+    for (const key of Object.keys(config)) {
+        const node = config[key];
+
+        if (isEnvField(node)) {
+            props[key] = node.schema;
+        } else if (typeof node === 'object' && node !== null) {
+            props[key] = buildSchema(node as Record<string, unknown>);
+        }
+    }
+
+    return object(props as any) as any;
+}
+
+/**
+ * Parses environment variables into a validated, typed config object.
+ *
+ * Every leaf field in the config descriptor must be wrapped with `env()` —
+ * this is enforced at the TypeScript level.
+ *
+ * The function:
+ * 1. Walks the descriptor tree, reading raw values from `source` (defaults
+ *    to `process.env`).
+ * 2. Assembles a `@cleverbrush/schema` object schema from the leaf schemas.
+ * 3. Validates and coerces the raw values via `schema.validate()`.
+ * 4. Returns the typed result or throws an `EnvValidationError` listing
+ *    all missing and invalid variables.
+ *
+ * @param config - A descriptor tree where leaves are `EnvField`s and
+ *   branches are plain objects.
+ * @param source - The environment variable source. Defaults to `process.env`.
+ *
+ * @example
+ * ```ts
+ * const config = parseEnv({
+ *   db: {
+ *     host: env('DB_HOST', string().default('localhost')),
+ *     port: env('DB_PORT', number().coerce().default(5432)),
+ *   },
+ *   debug: env('DEBUG', boolean().coerce().default(false)),
+ * });
+ * ```
+ */
+export function parseEnv<T extends EnvConfig>(
+    config: T,
+    source?: Record<string, string | undefined>
+): InferEnvConfig<T>;
+export function parseEnv<
+    T extends EnvConfig,
+    C extends Record<string, unknown>
+>(
+    config: T,
+    compute: (base: InferEnvConfig<T>) => C,
+    source?: Record<string, string | undefined>
+): Merge<[InferEnvConfig<T>, C]>;
+export function parseEnv<T extends EnvConfig>(
+    config: T,
+    computeOrSource?:
+        | ((base: InferEnvConfig<T>) => Record<string, unknown>)
+        | Record<string, string | undefined>,
+    maybeSource?: Record<string, string | undefined>
+): unknown {
+    const isCompute = typeof computeOrSource === 'function';
+    const source: Record<string, string | undefined> = isCompute
+        ? (maybeSource ?? (typeof process !== 'undefined' ? process.env : {}))
+        : (computeOrSource ??
+          (typeof process !== 'undefined' ? process.env : {}));
+
+    const { rawObject, mappings } = walkConfig(config, source, '');
+    const schema = buildSchema(config);
+
+    const result = schema.validate(rawObject, {
+        doNotStopOnFirstError: true
+    });
+
+    if (result.valid) {
+        const base = result.object as InferEnvConfig<T>;
+        if (isCompute) {
+            const computed = (
+                computeOrSource as (
+                    base: InferEnvConfig<T>
+                ) => Record<string, unknown>
+            )(base);
+            return deepExtend(base, computed);
+        }
+        return base;
+    }
+
+    // Map schema validation errors back to env var names
+    const missing: MissingEnvVar[] = [];
+    const invalid: InvalidEnvVar[] = [];
+
+    const errorMessages = result.errors?.map(e => e.message) ?? [];
+
+    // For each mapping, check if the var was present and if there's an error
+    for (const mapping of mappings) {
+        const raw = source[mapping.varName];
+        const introspected = mapping.schema.introspect();
+        const isRequired = introspected.isRequired;
+        const hasDefault = introspected.hasDefault;
+
+        if (raw === undefined || raw === '') {
+            if (isRequired && !hasDefault) {
+                missing.push({
+                    varName: mapping.varName,
+                    configPath: mapping.configPath,
+                    type: introspected.type
+                });
+            }
+        } else {
+            // Validate this individual field to see if it's invalid
+            const fieldResult = mapping.schema.validate(raw);
+            if (!fieldResult.valid) {
+                invalid.push({
+                    varName: mapping.varName,
+                    configPath: mapping.configPath,
+                    value: raw,
+                    errors: fieldResult.errors?.map(e => e.message) ?? []
+                });
+            }
+        }
+    }
+
+    // If we couldn't categorize any errors but validation still failed,
+    // add the raw error messages as a generic invalid entry
+    if (
+        missing.length === 0 &&
+        invalid.length === 0 &&
+        errorMessages.length > 0
+    ) {
+        invalid.push({
+            varName: '(unknown)',
+            configPath: '(unknown)',
+            value: '',
+            errors: errorMessages
+        });
+    }
+
+    throw new EnvValidationError(missing, invalid);
+}

--- a/libs/env/src/parseEnvFlat.ts
+++ b/libs/env/src/parseEnvFlat.ts
@@ -1,0 +1,45 @@
+import type { InferType, SchemaBuilder } from '@cleverbrush/schema';
+import { env } from './env.js';
+import { parseEnv } from './parseEnv.js';
+
+/**
+ * Flat schema map: keys are environment variable names, values are schema builders.
+ */
+type FlatEnvSchemas = Record<string, SchemaBuilder<any, any, any, any, any>>;
+
+/**
+ * Infers the runtime type from a flat schema map.
+ */
+type InferFlatEnv<T extends FlatEnvSchemas> = {
+    [K in keyof T]: InferType<T[K]>;
+};
+
+/**
+ * Convenience wrapper for simple flat configs where each key is both the
+ * config property name and the environment variable name.
+ *
+ * Equivalent to calling `parseEnv()` with every entry wrapped in `env()`.
+ *
+ * @param schemas - A record mapping env var names to schema builders.
+ * @param source  - The environment variable source. Defaults to `process.env`.
+ *
+ * @example
+ * ```ts
+ * const config = parseEnvFlat({
+ *   DB_HOST: string().default('localhost'),
+ *   DB_PORT: number().coerce().default(5432),
+ *   JWT_SECRET: string().minLength(32),
+ * });
+ * // Type: { DB_HOST: string, DB_PORT: number, JWT_SECRET: string }
+ * ```
+ */
+export function parseEnvFlat<T extends FlatEnvSchemas>(
+    schemas: T,
+    source?: Record<string, string | undefined>
+): InferFlatEnv<T> {
+    const config: Record<string, ReturnType<typeof env>> = {};
+    for (const key of Object.keys(schemas)) {
+        config[key] = env(key, schemas[key]);
+    }
+    return parseEnv(config as any, source) as InferFlatEnv<T>;
+}

--- a/libs/env/src/splitBy.ts
+++ b/libs/env/src/splitBy.ts
@@ -14,11 +14,11 @@
  * // "a, b, c" → ['a', 'b', 'c']
  * ```
  */
-export function splitBy<T = string>(separator: string): (value: T[]) => T[] {
-    return ((value: unknown): unknown => {
+export function splitBy(separator: string): (value: unknown) => unknown {
+    return (value: unknown): unknown => {
         if (typeof value === 'string') {
             return value.split(separator).map(s => s.trim());
         }
         return value;
-    }) as (value: T[]) => T[];
+    };
 }

--- a/libs/env/src/splitBy.ts
+++ b/libs/env/src/splitBy.ts
@@ -14,11 +14,11 @@
  * // "a, b, c" → ['a', 'b', 'c']
  * ```
  */
-export function splitBy(separator: string): (value: unknown) => unknown {
-    return (value: unknown): unknown => {
+export function splitBy<T = string>(separator: string): (value: T[]) => T[] {
+    return ((value: unknown): unknown => {
         if (typeof value === 'string') {
             return value.split(separator).map(s => s.trim());
         }
         return value;
-    };
+    }) as (value: T[]) => T[];
 }

--- a/libs/env/src/splitBy.ts
+++ b/libs/env/src/splitBy.ts
@@ -1,0 +1,24 @@
+/**
+ * Creates a preprocessor function that splits a string value by the given
+ * separator and trims each resulting element.
+ *
+ * Intended for use with `array()` schemas to parse comma-separated (or
+ * similarly delimited) environment variable values.
+ *
+ * @param separator - The delimiter string (e.g. `','`, `';'`, `' '`).
+ * @returns A preprocessor function suitable for `schema.addPreprocessor()`.
+ *
+ * @example
+ * ```ts
+ * env('ALLOWED_ORIGINS', array(string()).addPreprocessor(splitBy(','), { mutates: false }))
+ * // "a, b, c" → ['a', 'b', 'c']
+ * ```
+ */
+export function splitBy<T = string>(separator: string): (value: T[]) => T[] {
+    return ((value: unknown): unknown => {
+        if (typeof value === 'string') {
+            return value.split(separator).map(s => s.trim());
+        }
+        return value;
+    }) as (value: T[]) => T[];
+}

--- a/libs/env/src/types.ts
+++ b/libs/env/src/types.ts
@@ -1,0 +1,47 @@
+import type { InferType, SchemaBuilder } from '@cleverbrush/schema';
+
+/**
+ * Brand symbol used to distinguish EnvField from plain objects at the type level.
+ */
+export const ENV_FIELD_BRAND: unique symbol = Symbol('ENV_FIELD_BRAND');
+
+/**
+ * A branded wrapper around a schema builder that associates it with an
+ * environment variable name. Created exclusively by the {@link env} function.
+ */
+export type EnvField<T extends SchemaBuilder<any, any, any, any, any>> = {
+    readonly [ENV_FIELD_BRAND]: true;
+    readonly varName: string;
+    readonly schema: T;
+};
+
+/**
+ * A node in the config descriptor tree.
+ * - Leaf: an `EnvField` (created via `env()`)
+ * - Branch: a plain object whose values are themselves `EnvConfigNode`s
+ *
+ * Schema builders without `env()` wrapping intentionally fail to satisfy
+ * this type, producing a compile-time error.
+ */
+export type EnvConfigNode =
+    | EnvField<any>
+    | { readonly [key: string]: EnvConfigNode };
+
+/**
+ * Top-level config descriptor: a record of `EnvConfigNode`s.
+ */
+export type EnvConfig = Record<string, EnvConfigNode>;
+
+/**
+ * Recursively infers the runtime type from an `EnvConfig` descriptor tree.
+ *
+ * - `EnvField<S>` leaves resolve to `InferType<S>`
+ * - Object branches resolve to `{ [K]: InferEnvConfig<V> }`
+ */
+export type InferEnvConfig<T> = {
+    [K in keyof T]: T[K] extends EnvField<infer S>
+        ? InferType<S>
+        : T[K] extends Record<string, any>
+          ? InferEnvConfig<T[K]>
+          : never;
+};

--- a/libs/env/src/unit.test.ts
+++ b/libs/env/src/unit.test.ts
@@ -239,6 +239,32 @@ describe('parseEnv()', () => {
             }
         });
 
+        it('treats empty-string env var as missing (not coerced)', () => {
+            expect(() =>
+                parseEnv(
+                    {
+                        port: env('DB_PORT', number().coerce())
+                    },
+                    { DB_PORT: '' }
+                )
+            ).toThrow(EnvValidationError);
+
+            try {
+                parseEnv(
+                    {
+                        port: env('DB_PORT', number().coerce())
+                    },
+                    { DB_PORT: '' }
+                );
+                expect.unreachable('should have thrown');
+            } catch (e) {
+                expect(e).toBeInstanceOf(EnvValidationError);
+                const err = e as EnvValidationError;
+                expect(err.missing).toHaveLength(1);
+                expect(err.missing[0].varName).toBe('DB_PORT');
+            }
+        });
+
         it('reports multiple missing vars at once', () => {
             try {
                 parseEnv(

--- a/libs/env/src/unit.test.ts
+++ b/libs/env/src/unit.test.ts
@@ -1,0 +1,469 @@
+import { array, boolean, date, number, string } from '@cleverbrush/schema';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import {
+    EnvValidationError,
+    env,
+    parseEnv,
+    parseEnvFlat,
+    splitBy
+} from './index.js';
+
+describe('env()', () => {
+    it('creates a branded EnvField', () => {
+        const field = env('DB_HOST', string());
+        expect(field.varName).toBe('DB_HOST');
+        expect(field.schema).toBeDefined();
+    });
+
+    it('throws on empty varName', () => {
+        expect(() => env('', string())).toThrow('non-empty string');
+    });
+});
+
+describe('splitBy()', () => {
+    it('splits a string by separator and trims elements', () => {
+        const split = splitBy(',') as (value: unknown) => unknown;
+        expect(split('a, b, c')).toEqual(['a', 'b', 'c']);
+    });
+
+    it('returns non-string values unchanged', () => {
+        const split = splitBy(',') as (value: unknown) => unknown;
+        expect(split(42)).toBe(42);
+        expect(split(null)).toBe(null);
+        expect(split(undefined)).toBe(undefined);
+    });
+
+    it('handles single element (no separator present)', () => {
+        const split = splitBy(',') as (value: unknown) => unknown;
+        expect(split('single')).toEqual(['single']);
+    });
+});
+
+describe('parseEnv()', () => {
+    describe('flat config with env()', () => {
+        it('parses string values', () => {
+            const config = parseEnv(
+                {
+                    host: env('DB_HOST', string())
+                },
+                { DB_HOST: 'localhost' }
+            );
+            expect(config.host).toBe('localhost');
+            expectTypeOf(config.host).toBeString();
+        });
+
+        it('coerces number values', () => {
+            const config = parseEnv(
+                {
+                    port: env('DB_PORT', number().coerce())
+                },
+                { DB_PORT: '5432' }
+            );
+            expect(config.port).toBe(5432);
+            expectTypeOf(config.port).toBeNumber();
+        });
+
+        it('coerces boolean values', () => {
+            const config = parseEnv(
+                {
+                    debug: env('DEBUG', boolean().coerce())
+                },
+                { DEBUG: 'true' }
+            );
+            expect(config.debug).toBe(true);
+            expectTypeOf(config.debug).toBeBoolean();
+        });
+
+        it('coerces date values', () => {
+            const config = parseEnv(
+                {
+                    created: env('CREATED', date().coerce())
+                },
+                { CREATED: '2025-01-15' }
+            );
+            expect(config.created).toBeInstanceOf(Date);
+            expectTypeOf(config.created).toEqualTypeOf<Date>();
+        });
+    });
+
+    describe('nested config', () => {
+        it('parses nested object structures', () => {
+            const config = parseEnv(
+                {
+                    db: {
+                        host: env('DB_HOST', string()),
+                        port: env('DB_PORT', number().coerce()),
+                        name: env('DB_NAME', string())
+                    }
+                },
+                {
+                    DB_HOST: 'localhost',
+                    DB_PORT: '5432',
+                    DB_NAME: 'mydb'
+                }
+            );
+            expect(config.db.host).toBe('localhost');
+            expect(config.db.port).toBe(5432);
+            expect(config.db.name).toBe('mydb');
+            expectTypeOf(config.db.host).toBeString();
+            expectTypeOf(config.db.port).toBeNumber();
+            expectTypeOf(config.db.name).toBeString();
+        });
+
+        it('parses deeply nested structures (3+ levels)', () => {
+            const config = parseEnv(
+                {
+                    services: {
+                        auth: {
+                            jwt: {
+                                secret: env('JWT_SECRET', string())
+                            }
+                        }
+                    }
+                },
+                { JWT_SECRET: 'my-secret-key' }
+            );
+            expect(config.services.auth.jwt.secret).toBe('my-secret-key');
+            expectTypeOf(config.services.auth.jwt.secret).toBeString();
+        });
+    });
+
+    describe('defaults', () => {
+        it('applies default when env var is absent', () => {
+            const config = parseEnv(
+                {
+                    host: env('DB_HOST', string().default('localhost')),
+                    port: env('DB_PORT', number().coerce().default(5432))
+                },
+                {}
+            );
+            expect(config.host).toBe('localhost');
+            expect(config.port).toBe(5432);
+            expectTypeOf(config.host).toBeString();
+            expectTypeOf(config.port).toBeNumber();
+        });
+
+        it('uses env value over default when present', () => {
+            const config = parseEnv(
+                {
+                    host: env('DB_HOST', string().default('localhost'))
+                },
+                { DB_HOST: 'production-host' }
+            );
+            expect(config.host).toBe('production-host');
+        });
+    });
+
+    describe('arrays', () => {
+        it('parses comma-separated string into array via splitBy', () => {
+            const config = parseEnv(
+                {
+                    origins: env(
+                        'ALLOWED_ORIGINS',
+                        array(string()).addPreprocessor(splitBy(','), {
+                            mutates: false
+                        })
+                    )
+                },
+                { ALLOWED_ORIGINS: 'a, b, c' }
+            );
+            expect(config.origins).toEqual(['a', 'b', 'c']);
+            expectTypeOf(config.origins).toEqualTypeOf<string[]>();
+        });
+
+        it('parses comma-separated numbers', () => {
+            const config = parseEnv(
+                {
+                    ports: env(
+                        'PORTS',
+                        array(number().coerce()).addPreprocessor(splitBy(','), {
+                            mutates: false
+                        })
+                    )
+                },
+                { PORTS: '3000, 4000, 5000' }
+            );
+            expect(config.ports).toEqual([3000, 4000, 5000]);
+            expectTypeOf(config.ports).toEqualTypeOf<number[]>();
+        });
+    });
+
+    describe('error handling', () => {
+        it('throws EnvValidationError for missing required var', () => {
+            expect(() =>
+                parseEnv(
+                    {
+                        host: env('DB_HOST', string())
+                    },
+                    {}
+                )
+            ).toThrow(EnvValidationError);
+        });
+
+        it('includes var name and config path in missing error', () => {
+            try {
+                parseEnv(
+                    {
+                        db: {
+                            host: env('DB_HOST', string())
+                        }
+                    },
+                    {}
+                );
+                expect.unreachable('should have thrown');
+            } catch (e) {
+                expect(e).toBeInstanceOf(EnvValidationError);
+                const err = e as EnvValidationError;
+                expect(err.missing).toHaveLength(1);
+                expect(err.missing[0].varName).toBe('DB_HOST');
+                expect(err.missing[0].configPath).toBe('db.host');
+                expect(err.missing[0].type).toBe('string');
+            }
+        });
+
+        it('reports invalid values', () => {
+            try {
+                parseEnv(
+                    {
+                        port: env('DB_PORT', number().coerce())
+                    },
+                    { DB_PORT: 'not-a-number' }
+                );
+                expect.unreachable('should have thrown');
+            } catch (e) {
+                expect(e).toBeInstanceOf(EnvValidationError);
+                const err = e as EnvValidationError;
+                expect(err.invalid).toHaveLength(1);
+                expect(err.invalid[0].varName).toBe('DB_PORT');
+                expect(err.invalid[0].value).toBe('not-a-number');
+            }
+        });
+
+        it('reports multiple missing vars at once', () => {
+            try {
+                parseEnv(
+                    {
+                        db: {
+                            host: env('DB_HOST', string()),
+                            name: env('DB_NAME', string())
+                        },
+                        jwt: {
+                            secret: env('JWT_SECRET', string())
+                        }
+                    },
+                    {}
+                );
+                expect.unreachable('should have thrown');
+            } catch (e) {
+                expect(e).toBeInstanceOf(EnvValidationError);
+                const err = e as EnvValidationError;
+                expect(err.missing).toHaveLength(3);
+                const varNames = err.missing.map(m => m.varName).sort();
+                expect(varNames).toEqual(['DB_HOST', 'DB_NAME', 'JWT_SECRET']);
+            }
+        });
+
+        it('has formatted error message', () => {
+            try {
+                parseEnv(
+                    {
+                        host: env('DB_HOST', string())
+                    },
+                    {}
+                );
+                expect.unreachable('should have thrown');
+            } catch (e) {
+                const err = e as EnvValidationError;
+                expect(err.message).toContain('Missing environment variables');
+                expect(err.message).toContain('DB_HOST');
+                expect(err.message).toContain('host');
+            }
+        });
+    });
+
+    describe('mixed config', () => {
+        it('handles a realistic full config', () => {
+            const config = parseEnv(
+                {
+                    db: {
+                        host: env('DB_HOST', string().default('localhost')),
+                        port: env('DB_PORT', number().coerce().default(5432)),
+                        name: env('DB_NAME', string())
+                    },
+                    jwt: {
+                        secret: env('JWT_SECRET', string().minLength(8))
+                    },
+                    debug: env('DEBUG', boolean().coerce().default(false)),
+                    origins: env(
+                        'ALLOWED_ORIGINS',
+                        array(string()).addPreprocessor(splitBy(','), {
+                            mutates: false
+                        })
+                    )
+                },
+                {
+                    DB_NAME: 'prod',
+                    JWT_SECRET: 'super-secret-key',
+                    ALLOWED_ORIGINS: 'https://a.com, https://b.com'
+                }
+            );
+            expect(config.db.host).toBe('localhost');
+            expect(config.db.port).toBe(5432);
+            expect(config.db.name).toBe('prod');
+            expect(config.jwt.secret).toBe('super-secret-key');
+            expect(config.debug).toBe(false);
+            expect(config.origins).toEqual(['https://a.com', 'https://b.com']);
+            expectTypeOf(config.db.host).toBeString();
+            expectTypeOf(config.db.port).toBeNumber();
+            expectTypeOf(config.db.name).toBeString();
+            expectTypeOf(config.jwt.secret).toBeString();
+            expectTypeOf(config.debug).toBeBoolean();
+            expectTypeOf(config.origins).toEqualTypeOf<string[]>();
+        });
+    });
+});
+
+describe('parseEnvFlat()', () => {
+    it('parses flat schemas using keys as var names', () => {
+        const config = parseEnvFlat(
+            {
+                DB_HOST: string().default('localhost'),
+                DB_PORT: number().coerce().default(5432),
+                JWT_SECRET: string()
+            },
+            {
+                JWT_SECRET: 'secret123'
+            }
+        );
+        expect(config.DB_HOST).toBe('localhost');
+        expect(config.DB_PORT).toBe(5432);
+        expect(config.JWT_SECRET).toBe('secret123');
+        expectTypeOf(config.DB_HOST).toBeString();
+        expectTypeOf(config.DB_PORT).toBeNumber();
+        expectTypeOf(config.JWT_SECRET).toBeString();
+    });
+
+    it('throws EnvValidationError for missing flat vars', () => {
+        expect(() =>
+            parseEnvFlat(
+                {
+                    REQUIRED: string()
+                },
+                {}
+            )
+        ).toThrow(EnvValidationError);
+    });
+});
+
+describe('parseEnv() with compute callback', () => {
+    it('computes a derived value from base config', () => {
+        const config = parseEnv(
+            {
+                db: {
+                    host: env('DB_HOST', string()),
+                    port: env('DB_PORT', number().coerce()),
+                    name: env('DB_NAME', string())
+                }
+            },
+            base => ({
+                connectionString: `postgres://${base.db.host}:${base.db.port}/${base.db.name}`
+            }),
+            {
+                DB_HOST: 'localhost',
+                DB_PORT: '5432',
+                DB_NAME: 'mydb'
+            }
+        );
+        expect(config.db.host).toBe('localhost');
+        expect(config.db.port).toBe(5432);
+        expect(config.db.name).toBe('mydb');
+        expect(config.connectionString).toBe('postgres://localhost:5432/mydb');
+        expectTypeOf(config.connectionString).toBeString();
+        expectTypeOf(config.db.host).toBeString();
+        expectTypeOf(config.db.port).toBeNumber();
+    });
+
+    it('deep-merges nested computed values into base config', () => {
+        const config = parseEnv(
+            {
+                db: {
+                    host: env('DB_HOST', string()),
+                    port: env('DB_PORT', number().coerce())
+                }
+            },
+            base => ({
+                db: {
+                    url: `postgres://${base.db.host}:${base.db.port}`
+                }
+            }),
+            {
+                DB_HOST: 'localhost',
+                DB_PORT: '5432'
+            }
+        );
+        expect(config.db.host).toBe('localhost');
+        expect(config.db.port).toBe(5432);
+        expect(config.db.url).toBe('postgres://localhost:5432');
+        expectTypeOf(config.db.host).toBeString();
+        expectTypeOf(config.db.port).toBeNumber();
+        expectTypeOf(config.db.url).toBeString();
+    });
+
+    it('computes multiple derived values', () => {
+        const config = parseEnv(
+            {
+                host: env('HOST', string()),
+                port: env('PORT', number().coerce()),
+                debug: env('DEBUG', boolean().coerce().default(false))
+            },
+            base => ({
+                baseUrl: `http://${base.host}:${base.port}`,
+                isVerbose: base.debug
+            }),
+            {
+                HOST: 'example.com',
+                PORT: '3000'
+            }
+        );
+        expect(config.baseUrl).toBe('http://example.com:3000');
+        expect(config.isVerbose).toBe(false);
+        expectTypeOf(config.baseUrl).toBeString();
+        expectTypeOf(config.isVerbose).toBeBoolean();
+        expectTypeOf(config.host).toBeString();
+        expectTypeOf(config.port).toBeNumber();
+    });
+
+    it('works without explicit source (uses process.env)', () => {
+        const originalEnv = process.env;
+        process.env = { ...originalEnv, TEST_VAR: 'hello' };
+        try {
+            const config = parseEnv(
+                {
+                    value: env('TEST_VAR', string())
+                },
+                base => ({
+                    upper: base.value.toUpperCase()
+                })
+            );
+            expect(config.value).toBe('hello');
+            expect(config.upper).toBe('HELLO');
+            expectTypeOf(config.upper).toBeString();
+        } finally {
+            process.env = originalEnv;
+        }
+    });
+
+    it('throws EnvValidationError when base env vars are invalid', () => {
+        expect(() =>
+            parseEnv(
+                {
+                    host: env('DB_HOST', string())
+                },
+                base => ({
+                    url: `http://${base.host}`
+                }),
+                {}
+            )
+        ).toThrow(EnvValidationError);
+    });
+});

--- a/libs/env/tsconfig.build.json
+++ b/libs/env/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "./src",
+        "outDir": "./dist"
+    },
+    "references": [{ "path": "../deep" }, { "path": "../schema" }]
+}

--- a/libs/env/tsconfig.json
+++ b/libs/env/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "composite": true,
+        "rootDir": "./src",
+        "outDir": "./dist",
+        "declaration": true,
+        "target": "ES2022",
+        "module": "ES2022",
+        "esModuleInterop": true,
+        "moduleResolution": "bundler",
+        "allowSyntheticDefaultImports": true,
+        "sourceMap": false,
+        "declarationMap": false,
+        "types": ["node"]
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["src/**/*.test.ts"],
+    "watchOptions": {
+        "excludeDirectories": ["./dist"]
+    }
+}

--- a/libs/env/tsup.config.ts
+++ b/libs/env/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    tsconfig: './tsconfig.build.json',
+    minify: true,
+    sourcemap: true,
+    clean: true,
+    target: 'es2022'
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,17 @@
                 "@cleverbrush/schema": "^2.0.0"
             }
         },
+        "libs/env": {
+            "name": "@cleverbrush/env",
+            "version": "2.0.0",
+            "license": "BSD 3-Clause",
+            "dependencies": {
+                "@cleverbrush/schema": "^2.0.0"
+            },
+            "devDependencies": {
+                "@types/node": "^25.4.0"
+            }
+        },
         "libs/knex-clickhouse": {
             "name": "@cleverbrush/knex-clickhouse",
             "version": "2.0.0",
@@ -733,6 +744,10 @@
         },
         "node_modules/@cleverbrush/di": {
             "resolved": "libs/di",
+            "link": true
+        },
+        "node_modules/@cleverbrush/env": {
+            "resolved": "libs/env",
             "link": true
         },
         "node_modules/@cleverbrush/knex-clickhouse": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
             "version": "2.0.0",
             "license": "BSD 3-Clause",
             "dependencies": {
+                "@cleverbrush/deep": "^2.0.0",
                 "@cleverbrush/schema": "^2.0.0"
             },
             "devDependencies": {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,6 +11,7 @@
         { "path": "libs/scheduler" },
         { "path": "libs/di" },
         { "path": "libs/auth" },
-        { "path": "libs/server" }
+        { "path": "libs/server" },
+        { "path": "libs/env/tsconfig.build.json" }
     ]
 }

--- a/website/app/Navbar.tsx
+++ b/website/app/Navbar.tsx
@@ -10,6 +10,7 @@ const NAV_ITEMS = [
     { href: '/playground', label: 'Playground', highlight: true },
     { href: '/migrating-from-zod', label: 'vs Zod' },
     { href: '/mapper', label: 'Mapper' },
+    { href: '/env', label: 'Env' },
     { href: '/di', label: 'DI' },
     { href: '/server', label: 'Server' },
     { href: '/auth', label: 'Auth' },

--- a/website/app/env/page.tsx
+++ b/website/app/env/page.tsx
@@ -1,0 +1,469 @@
+/** biome-ignore-all lint/security/noDangerouslySetInnerHtml: needed to show examples */
+import { InstallBanner } from '@/app/InstallBanner';
+import { highlightTS } from '@/lib/highlight';
+
+export default function EnvPage() {
+    return (
+        <div className="page">
+            <div className="container">
+                <div className="section-header">
+                    <h1>@cleverbrush/env</h1>
+                    <p className="subtitle">
+                        Type-safe environment variable parsing — validated,
+                        coerced, structured configs from process.env.
+                    </p>
+                </div>
+
+                {/* ── Installation ─────────────────────────────────── */}
+                <InstallBanner
+                    command="npm install @cleverbrush/env"
+                    note={
+                        <>
+                            Requires <code>@cleverbrush/schema</code> as a peer
+                            dependency.
+                        </>
+                    }
+                />
+
+                {/* ── Why ──────────────────────────────────────────── */}
+                <div className="why-box">
+                    <h2>💡 Why @cleverbrush/env?</h2>
+
+                    <h3>The Problem</h3>
+                    <p>
+                        Environment variables are untyped strings. Most apps
+                        access them via <code>process.env.SOME_VAR!</code> — no
+                        validation, no coercion, no structure. Missing variables
+                        surface as runtime crashes. Secrets accidentally leak
+                        into frontend bundles. Config objects are ad-hoc and
+                        fragile.
+                    </p>
+
+                    <h3>The Solution</h3>
+                    <p>
+                        <code>@cleverbrush/env</code> uses{' '}
+                        <code>@cleverbrush/schema</code> builders for validation
+                        and coercion, and a branded <code>env()</code> wrapper
+                        for type-safe variable binding. TypeScript enforces at{' '}
+                        <strong>compile time</strong> that every config leaf is
+                        bound to an environment variable. At runtime, all
+                        variables are validated at once — with clear error
+                        messages for CI and startup logs.
+                    </p>
+
+                    <h3>Key Features</h3>
+                    <ul>
+                        <li>
+                            <strong>Compile-time enforcement</strong> —
+                            forgetting <code>env()</code> on a config leaf is a
+                            TypeScript error
+                        </li>
+                        <li>
+                            <strong>Nested configs</strong> — nest objects
+                            arbitrarily deep; env vars map to leaf fields
+                        </li>
+                        <li>
+                            <strong>Full schema power</strong> —{' '}
+                            <code>.minLength()</code>, <code>.coerce()</code>,{' '}
+                            <code>.default()</code>, custom validators
+                        </li>
+                        <li>
+                            <strong>Array support</strong> —{' '}
+                            <code>splitBy(',')</code> preprocessor for
+                            comma-separated values
+                        </li>
+                        <li>
+                            <strong>Computed values</strong> — derive values
+                            from resolved config via a type-safe callback,
+                            deep-merged into the result
+                        </li>
+                        <li>
+                            <strong>All-at-once errors</strong> — lists every
+                            missing and invalid variable in one message
+                        </li>
+                    </ul>
+                </div>
+
+                {/* ── Quick Start ──────────────────────────────────── */}
+                <div className="card">
+                    <h2>Quick Start — Structured Config</h2>
+                    <p>
+                        Define a nested config tree where every leaf is bound to
+                        an env var with <code>env()</code>. Types are inferred
+                        automatically:
+                    </p>
+                    <pre>
+                        <code
+                            dangerouslySetInnerHTML={{
+                                __html: highlightTS(`import { env, parseEnv, splitBy } from '@cleverbrush/env';
+import { string, number, boolean, array } from '@cleverbrush/schema';
+
+const config = parseEnv({
+  db: {
+    host: env('DB_HOST', string().default('localhost')),
+    port: env('DB_PORT', number().coerce().default(5432)),
+    name: env('DB_NAME', string()),
+  },
+  jwt: {
+    secret: env('JWT_SECRET', string().minLength(32)),
+  },
+  debug: env('DEBUG', boolean().coerce().default(false)),
+  allowedOrigins: env(
+    'ALLOWED_ORIGINS',
+    array(string()).addPreprocessor(splitBy(','), { mutates: false })
+  ),
+});
+
+// Inferred type:
+// {
+//   db: { host: string, port: number, name: string },
+//   jwt: { secret: string },
+//   debug: boolean,
+//   allowedOrigins: string[]
+// }
+
+config.db.host      // string
+config.db.port      // number (coerced from string)
+config.debug        // boolean (coerced from "true"/"false")
+config.allowedOrigins // string[] (split from "a,b,c")`)
+                            }}
+                        />
+                    </pre>
+                </div>
+
+                {/* ── Type Enforcement ─────────────────────────────── */}
+                <div className="card">
+                    <h2>Compile-Time Enforcement</h2>
+                    <p>
+                        The <code>parseEnv()</code> function only accepts config
+                        trees where every leaf is an <code>EnvField</code>{' '}
+                        (created by <code>env()</code>). Passing a bare schema
+                        builder is a TypeScript error:
+                    </p>
+                    <pre>
+                        <code
+                            dangerouslySetInnerHTML={{
+                                __html: highlightTS(`// ✗ Compile error — forgot env()
+parseEnv({
+  db: {
+    host: string(),
+    //    ^^^^^^^^ Type 'StringSchemaBuilder' is not
+    //             assignable to type 'EnvConfigNode'
+  },
+});
+
+// ✓ Correct — every leaf wrapped with env()
+parseEnv({
+  db: {
+    host: env('DB_HOST', string()),
+  },
+});`)
+                            }}
+                        />
+                    </pre>
+                </div>
+
+                {/* ── Flat Mode ────────────────────────────────────── */}
+                <div className="card">
+                    <h2>Flat Mode</h2>
+                    <p>
+                        For simple apps where each config key is also the env
+                        var name, use <code>parseEnvFlat()</code> — no{' '}
+                        <code>env()</code> wrapper needed:
+                    </p>
+                    <pre>
+                        <code
+                            dangerouslySetInnerHTML={{
+                                __html: highlightTS(`import { parseEnvFlat } from '@cleverbrush/env';
+import { string, number } from '@cleverbrush/schema';
+
+const config = parseEnvFlat({
+  DB_HOST: string().default('localhost'),
+  DB_PORT: number().coerce().default(5432),
+  JWT_SECRET: string().minLength(32),
+});
+// Type: { DB_HOST: string, DB_PORT: number, JWT_SECRET: string }`)
+                            }}
+                        />
+                    </pre>
+                </div>
+
+                {/* ── Arrays ───────────────────────────────────────── */}
+                <div className="card">
+                    <h2>Array Support</h2>
+                    <p>
+                        Use the <code>splitBy()</code> preprocessor to parse
+                        delimited strings into arrays:
+                    </p>
+                    <pre>
+                        <code
+                            dangerouslySetInnerHTML={{
+                                __html: highlightTS(`import { env, splitBy } from '@cleverbrush/env';
+import { array, string, number } from '@cleverbrush/schema';
+
+// Comma-separated strings → string[]
+env('ORIGINS', array(string()).addPreprocessor(splitBy(','), { mutates: false }))
+// "https://a.com, https://b.com" → ['https://a.com', 'https://b.com']
+
+// Comma-separated numbers → number[] (coerced per element)
+env('PORTS', array(number().coerce()).addPreprocessor(splitBy(','), { mutates: false }))
+// "3000, 4000, 5000" → [3000, 4000, 5000]`)
+                            }}
+                        />
+                    </pre>
+                </div>
+
+                {/* ── Computed Values ──────────────────────────────── */}
+                <div className="card">
+                    <h2>Computed Values</h2>
+                    <p>
+                        Derive values from the resolved config by passing a
+                        compute callback as the second argument. The callback
+                        receives the fully typed base config and returns an
+                        object that is <strong>deep-merged</strong> into the
+                        result:
+                    </p>
+                    <pre>
+                        <code
+                            dangerouslySetInnerHTML={{
+                                __html: highlightTS(`import { env, parseEnv } from '@cleverbrush/env';
+import { string, number } from '@cleverbrush/schema';
+
+const config = parseEnv(
+  {
+    db: {
+      host: env('DB_HOST', string().default('localhost')),
+      port: env('DB_PORT', number().coerce().default(5432)),
+      name: env('DB_NAME', string()),
+    },
+  },
+  (base) => ({
+    db: {
+      connectionString: \`postgres://\${base.db.host}:\${base.db.port}/\${base.db.name}\`,
+    },
+  })
+);
+
+// base is fully typed: { db: { host: string, port: number, name: string } }
+// Result: { db: { host, port, name, connectionString } }
+config.db.connectionString // "postgres://localhost:5432/mydb"`)
+                            }}
+                        />
+                    </pre>
+                    <p>
+                        When using a compute callback, the optional source is
+                        passed as the third argument:
+                    </p>
+                    <pre>
+                        <code
+                            dangerouslySetInnerHTML={{
+                                __html: highlightTS(`const config = parseEnv(
+  { host: env('HOST', string()) },
+  (base) => ({ url: \`http://\${base.host}\` }),
+  { HOST: 'example.com' }  // custom source
+);`)
+                            }}
+                        />
+                    </pre>
+                </div>
+
+                {/* ── Error Reporting ──────────────────────────────── */}
+                <div className="card">
+                    <h2>Error Reporting</h2>
+                    <p>
+                        When variables are missing or invalid,{' '}
+                        <code>parseEnv()</code> throws an{' '}
+                        <code>EnvValidationError</code> with a formatted message
+                        listing every problem at once:
+                    </p>
+                    <pre>
+                        <code
+                            dangerouslySetInnerHTML={{
+                                __html: highlightTS(`try {
+  const config = parseEnv({ ... });
+} catch (e) {
+  if (e instanceof EnvValidationError) {
+    console.error(e.message);
+    // Missing environment variables:
+    //   - DB_NAME (required by db.name) [string]
+    //   - JWT_SECRET (required by jwt.secret) [string]
+    // Invalid environment variables:
+    //   - DB_PORT: "abc" (required by db.port) — number expected
+
+    // Programmatic access:
+    e.missing  // [{ varName, configPath, type }]
+    e.invalid  // [{ varName, configPath, value, errors }]
+  }
+}`)
+                            }}
+                        />
+                    </pre>
+                </div>
+
+                {/* ── Comparison ───────────────────────────────────── */}
+                <div className="table-wrap">
+                    <h2>Comparison</h2>
+                    <table className="comparison-table">
+                        <thead>
+                            <tr>
+                                <th>Feature</th>
+                                <th>@cleverbrush/env</th>
+                                <th>t3-env</th>
+                                <th>envalid</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>Compile-time leaf enforcement</td>
+                                <td>✓</td>
+                                <td>✗</td>
+                                <td>✗</td>
+                            </tr>
+                            <tr>
+                                <td>Nested config structures</td>
+                                <td>✓</td>
+                                <td>✗</td>
+                                <td>✗</td>
+                            </tr>
+                            <tr>
+                                <td>Schema-based validation</td>
+                                <td>✓</td>
+                                <td>✓</td>
+                                <td>~</td>
+                            </tr>
+                            <tr>
+                                <td>Type coercion</td>
+                                <td>✓</td>
+                                <td>Manual</td>
+                                <td>✓</td>
+                            </tr>
+                            <tr>
+                                <td>Array support</td>
+                                <td>✓</td>
+                                <td>✗</td>
+                                <td>✗</td>
+                            </tr>
+                            <tr>
+                                <td>Computed / derived values</td>
+                                <td>✓</td>
+                                <td>✗</td>
+                                <td>✗</td>
+                            </tr>
+                            <tr>
+                                <td>All-at-once error reporting</td>
+                                <td>✓</td>
+                                <td>✓</td>
+                                <td>✓</td>
+                            </tr>
+                            <tr>
+                                <td>No Zod dependency</td>
+                                <td>✓</td>
+                                <td>✗</td>
+                                <td>✓</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                {/* ── API Reference ────────────────────────────────── */}
+                <div className="table-wrap">
+                    <h2>API Reference</h2>
+                    <table className="api-table">
+                        <thead>
+                            <tr>
+                                <th>Export</th>
+                                <th>Type</th>
+                                <th>Description</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>
+                                    <code>env(varName, schema)</code>
+                                </td>
+                                <td>Function</td>
+                                <td>
+                                    Binds a schema to an env var name. Required
+                                    for every leaf in <code>parseEnv()</code>.
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <code>parseEnv(config, source?)</code>
+                                </td>
+                                <td>Function</td>
+                                <td>
+                                    Parses env vars into a validated, typed
+                                    nested config object.
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <code>
+                                        parseEnv(config, compute, source?)
+                                    </code>
+                                </td>
+                                <td>Function</td>
+                                <td>
+                                    Parses env vars, then deep-merges computed
+                                    values from the callback.
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <code>parseEnvFlat(schemas, source?)</code>
+                                </td>
+                                <td>Function</td>
+                                <td>
+                                    Flat convenience — keys are env var names,
+                                    no <code>env()</code> needed.
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <code>splitBy(separator)</code>
+                                </td>
+                                <td>Function</td>
+                                <td>
+                                    Preprocessor that splits a string into an
+                                    array.
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <code>EnvValidationError</code>
+                                </td>
+                                <td>Class</td>
+                                <td>
+                                    Thrown when env vars are missing or invalid.
+                                    Has <code>.missing</code> and{' '}
+                                    <code>.invalid</code> properties.
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <code>EnvField&lt;T&gt;</code>
+                                </td>
+                                <td>Type</td>
+                                <td>
+                                    Branded wrapper type created by{' '}
+                                    <code>env()</code>.
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <code>InferEnvConfig&lt;T&gt;</code>
+                                </td>
+                                <td>Type</td>
+                                <td>
+                                    Infers the runtime type from a config
+                                    descriptor.
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/website/app/env/page.tsx
+++ b/website/app/env/page.tsx
@@ -16,10 +16,10 @@ export default function EnvPage() {
 
                 {/* ── Installation ─────────────────────────────────── */}
                 <InstallBanner
-                    command="npm install @cleverbrush/env"
+                    command="npm install @cleverbrush/env @cleverbrush/schema"
                     note={
                         <>
-                            Includes <code>@cleverbrush/schema</code> as a
+                            Requires <code>@cleverbrush/schema</code> as a peer
                             dependency.
                         </>
                     }

--- a/website/app/env/page.tsx
+++ b/website/app/env/page.tsx
@@ -19,7 +19,7 @@ export default function EnvPage() {
                     command="npm install @cleverbrush/env"
                     note={
                         <>
-                            Requires <code>@cleverbrush/schema</code> as a peer
+                            Includes <code>@cleverbrush/schema</code> as a
                             dependency.
                         </>
                     }


### PR DESCRIPTION
… parsing

- Implement `parseEnvFlat` for flat schema parsing with environment variables.
- Introduce `splitBy` function for preprocessing string values into arrays.
- Define types for environment variable schemas and validation errors.
- Create unit tests for environment variable parsing and validation.
- Add TypeScript configuration for building the library.
- Update package-lock.json to include new library dependencies.
- Enhance website documentation with a dedicated page for @cleverbrush/env.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [X] Documentation update
- [ ] Refactor / internal improvement

## Checklist

- [X] I've added tests for my changes
- [X] I've run `npm run lint` and fixed any issues
- [X] I've run `npm run test` and all tests pass
- [X] I've added a changeset (`npx changeset`) if this changes package behavior
