### PR TITLE
Add type MergeTwo to exports from deepExtend module

### DIFF
--- a/libs/deep/src/index.ts
+++ b/libs/deep/src/index.ts
@@ -1,5 +1,5 @@
 import { deepEqual } from './deepEqual.js';
-import { deepExtend, type Merge } from './deepExtend.js';
+import { deepExtend, type Merge, type MergeTwo } from './deepExtend.js';
 import { deepFlatten } from './deepFlatten.js';
 
-export { deepEqual, deepExtend, deepFlatten, type Merge };
+export { deepEqual, deepExtend, deepFlatten, type Merge, type MergeTwo };


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / internal improvement

## Checklist

- [ ] I've added tests for my changes
- [ ] I've run `npm run lint` and fixed any issues
- [ ] I've run `npm run test` and all tests pass
- [ ] I've added a changeset (`npx changeset`) if this changes package behavior
